### PR TITLE
feat: Add LPDF file format support for importing/exporting PDFs with …

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"@vercel/analytics": "^1.5.0",
 		"autoprefixer": "^10.4.21",
 		"jspdf": "^3.0.2",
+		"jszip": "^3.10.1",
 		"lucide-svelte": "^0.544.0",
 		"markdown-it": "^14.1.0",
 		"pdf-lib": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "leedpdf",
 	"private": true,
-	"version": "2.7.0",
+	"version": "2.8.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       jspdf:
         specifier: ^3.0.2
         version: 3.0.2
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-svelte:
         specifier: ^0.544.0
         version: 0.544.0(svelte@5.38.3)
@@ -1945,6 +1948,9 @@ packages:
   core-js@3.45.1:
     resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2432,6 +2438,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2591,6 +2600,9 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -2684,6 +2696,9 @@ packages:
   jspdf@3.0.2:
     resolution: {integrity: sha512-G0fQDJ5fAm6UW78HG6lNXyq09l0PrA1rpNY5i+ly17Zb1fMMFSmS+3lw4cnrAPGyouv2Y0ylujbY2Ieq3DSlKA==}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2704,6 +2719,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -3156,6 +3174,9 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
@@ -3184,6 +3205,9 @@ packages:
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -3281,6 +3305,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3325,6 +3352,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3425,6 +3455,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   stringify-object@3.3.0:
     resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
@@ -5818,6 +5851,8 @@ snapshots:
 
   core-js@3.45.1: {}
 
+  core-util-is@1.0.3: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -6433,6 +6468,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -6586,6 +6623,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -6696,6 +6735,13 @@ snapshots:
       dompurify: 3.2.6
       html2canvas: 1.4.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -6712,6 +6758,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@2.1.0: {}
 
@@ -7097,6 +7147,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  process-nextick-args@2.0.1: {}
+
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -7123,6 +7175,16 @@ snapshots:
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@3.6.0:
     dependencies:
@@ -7248,6 +7310,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
@@ -7298,6 +7362,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -7428,6 +7494,10 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   stringify-object@3.3.0:
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2263,7 +2263,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leed-pdf"
-version = "2.4.0"
+version = "2.8.0"
 dependencies = [
  "log",
  "machine-uid",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leed-pdf"
-version = "2.5.0"
+version = "2.8.0"
 description = "A Lightweight, Opensource and Free PDF Viewer"
 authors = ["Rudi K <reach@rudi.engineer>"]
 license = "AGPL"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,7 +50,7 @@ fn check_file_associations() -> Vec<String> {
 
     for arg in &args[1..] {
         let clean_arg = sanitize_path(arg);
-        if clean_arg.to_lowercase().ends_with(".pdf") {
+        if clean_arg.to_lowercase().ends_with(".pdf") || clean_arg.to_lowercase().ends_with(".lpdf") {
             pdf_files.push(clean_arg);
         }
     }
@@ -475,9 +475,9 @@ pub fn run() {
                         let clean_arg = sanitize_path(arg);
                         debug_msg.push_str(&format!("Processing argument: {} -> {}\n", arg, clean_arg));
 
-                        if clean_arg.to_lowercase().ends_with(".pdf") {
+                        if clean_arg.to_lowercase().ends_with(".pdf") || clean_arg.to_lowercase().ends_with(".lpdf") {
                             pdf_files.push(clean_arg.clone());
-                            debug_msg.push_str(&format!("Found PDF file: {}\n", clean_arg));
+                            debug_msg.push_str(&format!("Found PDF/LPDF file: {}\n", clean_arg));
                         }
                     }
 
@@ -501,7 +501,7 @@ pub fn run() {
                     let mut pdf_files: Vec<String> = Vec::new();
                     for arg in &args[1..] {
                         let clean_arg = sanitize_path(arg);
-                        if clean_arg.to_lowercase().ends_with(".pdf") {
+                        if clean_arg.to_lowercase().ends_with(".pdf") || clean_arg.to_lowercase().ends_with(".lpdf") {
                             pdf_files.push(clean_arg.clone());
                         }
                     }
@@ -540,9 +540,9 @@ pub fn run() {
                             
                             println!("Decoded path: {}", decoded_path);
                             
-                            if decoded_path.to_lowercase().ends_with(".pdf") {
+                            if decoded_path.to_lowercase().ends_with(".pdf") || decoded_path.to_lowercase().ends_with(".lpdf") {
                                 pdf_files.push(decoded_path.to_string());
-                                println!("Found PDF file from opened event: {}", decoded_path);
+                                println!("Found PDF/LPDF file from opened event: {}", decoded_path);
                             } else {
                                 println!("Not a PDF file: {}", decoded_path);
                             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,6 +50,13 @@
         "role": "Editor",
         "rank": "Owner",
         "description": "LeedPDF Annotatable Markdown Document"
+      },
+      {
+        "name": "LeedPDF Document",
+        "ext": ["lpdf"],
+        "role": "Editor",
+        "rank": "Owner",
+        "description": "LeedPDF Annotatable Document"
       }
     ]
   },

--- a/src/lib/components/DragOverlay.svelte
+++ b/src/lib/components/DragOverlay.svelte
@@ -11,7 +11,7 @@
         <FileText class="w-16 h-16 mx-auto" />
       </div>
       <h3 class="text-2xl font-bold text-charcoal mb-2">Drop your file here</h3>
-      <p class="text-slate">Release to start (PDF or Markdown)</p>
+      <p class="text-slate">Release to start (PDF, Markdown, or LPDF)</p>
       <div class="mt-4 text-sm text-sage font-medium">Ready to receive file</div>
     </div>
   </div>

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -178,7 +178,7 @@
 <input
   bind:this={fileInput}
   type="file"
-  accept=".pdf,.lpdf,application/pdf"
+  accept=".pdf,.lpdf,.md,.markdown"
   on:change={handleFileChange}
   class="hidden"
   aria-hidden="true"

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -31,10 +31,12 @@
 		Download,
 		Edit3,
 		Folder,
+		FolderOpen,
 		Highlighter,
 		Layout,
 		Moon,
 		MoreHorizontal,
+		Package,
 		Redo2,
 		Search,
 		Square,
@@ -70,6 +72,7 @@
   export let onFitToWidth: () => void;
   export let onFitToHeight: () => void;
   export let onExportPDF: () => void;
+  export let onExportLPDF: () => void;
   
   // Thumbnail panel control
   export let showThumbnails = false;
@@ -81,6 +84,7 @@
   let showEraserSizePicker = false;
   let showStampPalette = false;
   let showMoreMenu = false;
+  let showExportMenu = false;
   let toolbarScrollContainer: HTMLDivElement;
   let showLeftFade = false;
   let showRightFade = true;
@@ -119,6 +123,7 @@
       onFileUpload(input.files);
     }
   }
+
 
   function handleUndo() {
     undo();
@@ -161,10 +166,24 @@
     if (!target.closest('.stamp-palette-container')) {
       showStampPalette = false;
     }
+    if (!target.closest('.export-menu-container')) {
+      showExportMenu = false;
+    }
   }
 </script>
 
 <svelte:window on:click={handleClickOutside} />
+
+<!-- Hidden file inputs -->
+<input
+  bind:this={fileInput}
+  type="file"
+  accept=".pdf,.lpdf,application/pdf"
+  on:change={handleFileChange}
+  class="hidden"
+  aria-hidden="true"
+/>
+
 
 <!-- Top Toolbar - Always visible -->
 <div class="toolbar-top fixed top-2 left-4 right-4 z-50">
@@ -540,15 +559,39 @@
             <Trash2 size={16} class="lg:w-3.5 lg:h-3.5" />
           </button>
 
-          <button
-            class="tool-button w-11 h-11 lg:w-8 lg:h-8 flex items-center justify-center text-sage hover:bg-sage/10"
-            class:opacity-50={!$pdfState.document}
-            disabled={!$pdfState.document}
-            on:click={onExportPDF}
-            title="Export annotated PDF"
-          >
-            <Download size={16} class="lg:w-3.5 lg:h-3.5" />
-          </button>
+          <!-- Export Menu -->
+          <div class="relative export-menu-container">
+            <button
+              class="tool-button w-11 h-11 lg:w-8 lg:h-8 flex items-center justify-center text-sage hover:bg-sage/10"
+              class:opacity-50={!$pdfState.document}
+              disabled={!$pdfState.document}
+              on:click={() => showExportMenu = !showExportMenu}
+              title="Export options"
+            >
+              <Download size={16} class="lg:w-3.5 lg:h-3.5" />
+            </button>
+
+            {#if showExportMenu}
+              <div class="absolute top-full mt-2 right-0 z-50 min-w-[180px]">
+                <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 p-2">
+                  <button
+                    class="w-full text-left p-2 rounded-lg hover:bg-sage/10 transition-colors text-sm flex items-center gap-2"
+                    on:click={() => { onExportPDF(); showExportMenu = false; }}
+                  >
+                    <Download size={16} class="text-sage" />
+                    Export as PDF
+                  </button>
+                  <button
+                    class="w-full text-left p-2 rounded-lg hover:bg-sage/10 transition-colors text-sm flex items-center gap-2"
+                    on:click={() => { onExportLPDF(); showExportMenu = false; }}
+                  >
+                    <Package size={16} class="text-sage" />
+                    Export as LPDF
+                  </button>
+                </div>
+              </div>
+            {/if}
+          </div>
         </div>
 
         <!-- Desktop: Current tool indicator, Light/Dark mode -->
@@ -628,7 +671,27 @@
                     class="w-full text-left p-2 rounded-lg hover:bg-sage/10 transition-colors text-sm"
                     on:click={() => { handleFileSelect(); showMoreMenu = false; }}
                   >
-                    📁 Open other file
+                    📁 Open PDF file
+                  </button>
+                </div>
+
+                <!-- Export operations -->
+                <div class="space-y-1 mb-3">
+                  <button
+                    class="w-full text-left p-2 rounded-lg hover:bg-sage/10 transition-colors text-sm"
+                    class:opacity-50={!$pdfState.document}
+                    disabled={!$pdfState.document}
+                    on:click={() => { onExportPDF(); showMoreMenu = false; }}
+                  >
+                    📄 Export as PDF
+                  </button>
+                  <button
+                    class="w-full text-left p-2 rounded-lg hover:bg-sage/10 transition-colors text-sm"
+                    class:opacity-50={!$pdfState.document}
+                    disabled={!$pdfState.document}
+                    on:click={() => { onExportLPDF(); showMoreMenu = false; }}
+                  >
+                    📦 Export as LPDF
                   </button>
                 </div>
 
@@ -1014,16 +1077,6 @@
     </div>
   </div>
 {/if}
-
-<!-- Hidden file input -->
-<input
-  bind:this={fileInput}
-  type="file"
-  accept=".pdf,.md,.markdown,application/pdf,text/markdown"
-  multiple={false}
-  class="hidden"
-  on:change={handleFileChange}
-/>
 
 <style>
   .toolbar-top,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,6 +3,11 @@ export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 export const WARNING_FILE_SIZE = 15 * 1024 * 1024; // 15MB
 export const SESSION_MAX_FILE_SIZE = 15 * 1024 * 1024; // 15MB for sessionStorage fallback
 
+// LPDF security limits
+export const LPDF_MAX_PDF_SIZE = MAX_FILE_SIZE; // Max size for PDF inside LPDF
+export const LPDF_MAX_JSON_SIZE = 10 * 1024 * 1024; // 10MB max for annotations.json
+export const LPDF_MAX_TOTAL_UNCOMPRESSED = 100 * 1024 * 1024; // 100MB max total uncompressed size
+
 // Storage configuration
 export const MAX_STORAGE_TIME = 2 * 60 * 60 * 1000; // 2 hours
 export const AUTO_CLEANUP_INTERVAL = 30 * 60 * 1000; // 30 minutes

--- a/src/lib/utils/lpdfExport.ts
+++ b/src/lib/utils/lpdfExport.ts
@@ -1,0 +1,534 @@
+import JSZip from 'jszip';
+import type {
+	DrawingPath,
+	TextAnnotation,
+	StickyNoteAnnotation,
+	StampAnnotation,
+	ArrowAnnotation,
+	StampDefinition
+} from '$lib/stores/drawingStore';
+import {
+	drawingPaths,
+	textAnnotations,
+	stickyNoteAnnotations,
+	stampAnnotations,
+	arrowAnnotations,
+	availableStamps,
+	setCurrentPDF,
+	forceSaveAllAnnotations
+} from '$lib/stores/drawingStore';
+import { pdfState } from '$lib/stores/drawingStore';
+import { get } from 'svelte/store';
+import { toastStore } from '$lib/stores/toastStore';
+import { PDFExporter } from './pdfExport';
+
+/**
+ * Complete annotation data structure for .lpdf format
+ * This matches the structure from your Python reference implementation
+ */
+export interface LPDFAnnotationData {
+	// Drawing paths (freehand drawing, highlighting, etc.)
+	drawings: {
+		[pageNumber: string]: Array<{
+			tool: string;
+			color: string;
+			lineWidth: number;
+			points: Array<{
+				x: number;
+				y: number;
+				pressure?: number;
+				relativeX?: number;
+				relativeY?: number;
+			}>;
+			highlightColor?: string;
+			highlightOpacity?: number;
+			viewerScale?: number;
+		}>;
+	};
+	
+	// Text annotations
+	textAnnotations: {
+		[pageNumber: string]: Array<{
+			id: string;
+			x: number;
+			y: number;
+			text: string;
+			fontSize: number;
+			color: string;
+			fontFamily: string;
+			relativeX: number;
+			relativeY: number;
+		}>;
+	};
+	
+	// Sticky note annotations
+	stickyNotes: {
+		[pageNumber: string]: Array<{
+			id: string;
+			x: number;
+			y: number;
+			text: string;
+			fontSize: number;
+			fontFamily: string;
+			backgroundColor: string;
+			width: number;
+			height: number;
+			relativeX: number;
+			relativeY: number;
+			relativeWidth: number;
+			relativeHeight: number;
+		}>;
+	};
+	
+	// Stamp annotations
+	stamps: {
+		[pageNumber: string]: Array<{
+			id: string;
+			x: number;
+			y: number;
+			stampId: string;
+			size: number;
+			rotation: number;
+			relativeX: number;
+			relativeY: number;
+			relativeSize: number;
+			width?: number;
+			height?: number;
+		}>;
+	};
+	
+	// Arrow annotations
+	arrows: {
+		[pageNumber: string]: Array<{
+			id: string;
+			x1: number;
+			y1: number;
+			x2: number;
+			y2: number;
+			stroke: string;
+			strokeWidth: number;
+			arrowHead: boolean;
+			relativeX1: number;
+			relativeY1: number;
+			relativeX2: number;
+			relativeY2: number;
+		}>;
+	};
+	
+	// Metadata
+	metadata: {
+		version: string;
+		created: number;
+		appVersion: string;
+		totalPages: number;
+		stamps?: StampDefinition[]; // Include available stamps for compatibility
+	};
+}
+
+export class LPDFExporter {
+	private originalPdfBytes: Uint8Array | null = null;
+	private currentFileName: string = '';
+
+	/**
+	 * Set the original PDF data
+	 */
+	setOriginalPDF(pdfBytes: Uint8Array, fileName: string = 'document.pdf') {
+		this.originalPdfBytes = pdfBytes;
+		this.currentFileName = fileName;
+	}
+
+	/**
+	 * Collect all annotation data from stores
+	 */
+	private collectAnnotationData(): LPDFAnnotationData {
+		const currentPdfState = get(pdfState);
+		
+		// Get all annotation data from stores
+		const allDrawingPaths = get(drawingPaths);
+		const allTextAnnotations = get(textAnnotations);
+		const allStickyNotes = get(stickyNoteAnnotations);
+		const allStampAnnotations = get(stampAnnotations);
+		const allArrowAnnotations = get(arrowAnnotations);
+
+		// Convert drawing paths
+		const drawings: LPDFAnnotationData['drawings'] = {};
+		allDrawingPaths.forEach((paths, pageNumber) => {
+			if (paths.length > 0) {
+				drawings[pageNumber.toString()] = paths.map(path => ({
+					tool: path.tool,
+					color: path.color,
+					lineWidth: path.lineWidth,
+					points: path.points,
+					highlightColor: path.highlightColor,
+					highlightOpacity: path.highlightOpacity,
+					viewerScale: path.viewerScale
+				}));
+			}
+		});
+
+		// Convert text annotations
+		const textAnnotationsData: LPDFAnnotationData['textAnnotations'] = {};
+		allTextAnnotations.forEach((annotations, pageNumber) => {
+			if (annotations.length > 0) {
+				textAnnotationsData[pageNumber.toString()] = annotations.map(annotation => ({
+					id: annotation.id,
+					x: annotation.x,
+					y: annotation.y,
+					text: annotation.text,
+					fontSize: annotation.fontSize,
+					color: annotation.color,
+					fontFamily: annotation.fontFamily,
+					relativeX: annotation.relativeX,
+					relativeY: annotation.relativeY
+				}));
+			}
+		});
+
+		// Convert sticky notes
+		const stickyNotesData: LPDFAnnotationData['stickyNotes'] = {};
+		allStickyNotes.forEach((notes, pageNumber) => {
+			if (notes.length > 0) {
+				stickyNotesData[pageNumber.toString()] = notes.map(note => ({
+					id: note.id,
+					x: note.x,
+					y: note.y,
+					text: note.text,
+					fontSize: note.fontSize,
+					fontFamily: note.fontFamily,
+					backgroundColor: note.backgroundColor,
+					width: note.width,
+					height: note.height,
+					relativeX: note.relativeX,
+					relativeY: note.relativeY,
+					relativeWidth: note.relativeWidth,
+					relativeHeight: note.relativeHeight
+				}));
+			}
+		});
+
+		// Convert stamps
+		const stampsData: LPDFAnnotationData['stamps'] = {};
+		allStampAnnotations.forEach((stamps, pageNumber) => {
+			if (stamps.length > 0) {
+				stampsData[pageNumber.toString()] = stamps.map(stamp => ({
+					id: stamp.id,
+					x: stamp.x,
+					y: stamp.y,
+					stampId: stamp.stampId,
+					size: stamp.size,
+					rotation: stamp.rotation,
+					relativeX: stamp.relativeX,
+					relativeY: stamp.relativeY,
+					relativeSize: stamp.relativeSize,
+					width: stamp.width,
+					height: stamp.height
+				}));
+			}
+		});
+
+		// Convert arrows
+		const arrowsData: LPDFAnnotationData['arrows'] = {};
+		allArrowAnnotations.forEach((arrows, pageNumber) => {
+			if (arrows.length > 0) {
+				arrowsData[pageNumber.toString()] = arrows.map(arrow => ({
+					id: arrow.id,
+					x1: arrow.x1,
+					y1: arrow.y1,
+					x2: arrow.x2,
+					y2: arrow.y2,
+					stroke: arrow.stroke,
+					strokeWidth: arrow.strokeWidth,
+					arrowHead: arrow.arrowHead,
+					relativeX1: arrow.relativeX1,
+					relativeY1: arrow.relativeY1,
+					relativeX2: arrow.relativeX2,
+					relativeY2: arrow.relativeY2
+				}));
+			}
+		});
+
+		return {
+			drawings,
+			textAnnotations: textAnnotationsData,
+			stickyNotes: stickyNotesData,
+			stamps: stampsData,
+			arrows: arrowsData,
+			metadata: {
+				version: '1.0',
+				created: Date.now(),
+				appVersion: '2.7.0', // From package.json
+				totalPages: currentPdfState.totalPages,
+				stamps: availableStamps // Include stamp definitions for compatibility
+			}
+		};
+	}
+
+	/**
+	 * Export current PDF and annotations to .lpdf format
+	 */
+	async exportToLPDF(): Promise<Uint8Array> {
+		if (!this.originalPdfBytes) {
+			throw new Error('No original PDF loaded. Please set the PDF data first.');
+		}
+
+		try {
+			console.log('Starting .lpdf export...');
+			
+			// Force save all annotations to ensure we have the latest data
+			forceSaveAllAnnotations();
+			
+			// Collect all annotation data
+			const annotationData = this.collectAnnotationData();
+			
+			console.log('Collected annotation data:', {
+				drawingsPages: Object.keys(annotationData.drawings).length,
+				textAnnotationsPages: Object.keys(annotationData.textAnnotations).length,
+				stickyNotesPages: Object.keys(annotationData.stickyNotes).length,
+				stampsPages: Object.keys(annotationData.stamps).length,
+				arrowsPages: Object.keys(annotationData.arrows).length,
+				totalPages: annotationData.metadata.totalPages
+			});
+
+			// Create ZIP file
+			const zip = new JSZip();
+			
+			// Add original PDF
+			zip.file('original.pdf', this.originalPdfBytes);
+			
+			// Add annotations as JSON
+			const annotationsJson = JSON.stringify(annotationData, null, 2);
+			zip.file('annotations.json', annotationsJson);
+			
+			console.log('Created ZIP with original.pdf and annotations.json');
+			
+			// Generate the .lpdf file
+			const lpdfBytes = await zip.generateAsync({
+				type: 'uint8array',
+				compression: 'DEFLATE',
+				compressionOptions: {
+					level: 6
+				}
+			});
+			
+			console.log(`Successfully generated .lpdf file (${lpdfBytes.length} bytes)`);
+			return lpdfBytes;
+		} catch (error) {
+			console.error('Error creating .lpdf file:', error);
+			throw new Error(`Failed to create .lpdf file: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		}
+	}
+
+	/**
+	 * Read and parse an .lpdf file
+	 */
+	static async importFromLPDF(lpdfFile: File): Promise<{
+		pdfFile: File;
+		annotations: LPDFAnnotationData;
+	}> {
+		try {
+			console.log('Starting .lpdf import...');
+			
+			// Read the ZIP file
+			const zip = await JSZip.loadAsync(lpdfFile);
+			
+			// Extract original PDF
+			const pdfZipEntry = zip.file('original.pdf');
+			if (!pdfZipEntry) {
+				throw new Error('Invalid .lpdf file: missing original.pdf');
+			}
+			
+			const pdfBytes = await pdfZipEntry.async('uint8array');
+			const pdfFile = new File([pdfBytes.buffer as ArrayBuffer], 'document.pdf', { type: 'application/pdf' });
+			
+			// Extract annotations
+			const annotationsZipEntry = zip.file('annotations.json');
+			if (!annotationsZipEntry) {
+				throw new Error('Invalid .lpdf file: missing annotations.json');
+			}
+			
+			const annotationsJson = await annotationsZipEntry.async('text');
+			const annotations: LPDFAnnotationData = JSON.parse(annotationsJson);
+			
+			console.log('Successfully parsed .lpdf file:', {
+				pdfSize: pdfBytes.length,
+				annotationPages: Object.keys(annotations.drawings).length + 
+					Object.keys(annotations.textAnnotations).length + 
+					Object.keys(annotations.stickyNotes).length + 
+					Object.keys(annotations.stamps).length + 
+					Object.keys(annotations.arrows).length
+			});
+			
+			return { pdfFile, annotations };
+		} catch (error) {
+			console.error('Error reading .lpdf file:', error);
+			throw new Error(`Failed to read .lpdf file: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		}
+	}
+
+	/**
+	 * Load annotations from LPDF data into the application stores
+	 */
+	static async loadAnnotationsIntoStores(annotations: LPDFAnnotationData, fileName: string, fileSize: number) {
+		try {
+			console.log('Loading annotations into stores...');
+			
+			// Set current PDF to associate annotations with the correct PDF
+			setCurrentPDF(fileName, fileSize);
+			
+			// Clear existing annotations
+			drawingPaths.set(new Map());
+			textAnnotations.set(new Map());
+			stickyNoteAnnotations.set(new Map());
+			stampAnnotations.set(new Map());
+			arrowAnnotations.set(new Map());
+			
+			// Load drawing paths
+			if (annotations.drawings) {
+				const drawingPathsMap = new Map<number, DrawingPath[]>();
+				Object.entries(annotations.drawings).forEach(([pageNum, paths]) => {
+					const pageNumber = parseInt(pageNum);
+					const convertedPaths: DrawingPath[] = paths.map(path => ({
+						tool: path.tool as any,
+						color: path.color,
+						lineWidth: path.lineWidth,
+						points: path.points,
+						pageNumber,
+						highlightColor: path.highlightColor,
+						highlightOpacity: path.highlightOpacity,
+						viewerScale: path.viewerScale
+					}));
+					drawingPathsMap.set(pageNumber, convertedPaths);
+				});
+				drawingPaths.set(drawingPathsMap);
+			}
+			
+			// Load text annotations
+			if (annotations.textAnnotations) {
+				const textAnnotationsMap = new Map<number, TextAnnotation[]>();
+				Object.entries(annotations.textAnnotations).forEach(([pageNum, texts]) => {
+					const pageNumber = parseInt(pageNum);
+					const convertedTexts: TextAnnotation[] = texts.map(text => ({
+						...text,
+						pageNumber
+					}));
+					textAnnotationsMap.set(pageNumber, convertedTexts);
+				});
+				textAnnotations.set(textAnnotationsMap);
+			}
+			
+			// Load sticky notes
+			if (annotations.stickyNotes) {
+				const stickyNotesMap = new Map<number, StickyNoteAnnotation[]>();
+				Object.entries(annotations.stickyNotes).forEach(([pageNum, notes]) => {
+					const pageNumber = parseInt(pageNum);
+					const convertedNotes: StickyNoteAnnotation[] = notes.map(note => ({
+						...note,
+						pageNumber
+					}));
+					stickyNotesMap.set(pageNumber, convertedNotes);
+				});
+				stickyNoteAnnotations.set(stickyNotesMap);
+			}
+			
+			// Load stamps
+			if (annotations.stamps) {
+				const stampsMap = new Map<number, StampAnnotation[]>();
+				Object.entries(annotations.stamps).forEach(([pageNum, stamps]) => {
+					const pageNumber = parseInt(pageNum);
+					const convertedStamps: StampAnnotation[] = stamps.map(stamp => ({
+						...stamp,
+						pageNumber
+					}));
+					stampsMap.set(pageNumber, convertedStamps);
+				});
+				stampAnnotations.set(stampsMap);
+			}
+			
+			// Load arrows
+			if (annotations.arrows) {
+				const arrowsMap = new Map<number, ArrowAnnotation[]>();
+				Object.entries(annotations.arrows).forEach(([pageNum, arrows]) => {
+					const pageNumber = parseInt(pageNum);
+					const convertedArrows: ArrowAnnotation[] = arrows.map(arrow => ({
+						...arrow,
+						pageNumber
+					}));
+					arrowsMap.set(pageNumber, convertedArrows);
+				});
+				arrowAnnotations.set(arrowsMap);
+			}
+			
+			console.log('Successfully loaded all annotations into stores');
+			
+			// Force save to localStorage to persist the imported data
+			forceSaveAllAnnotations();
+			
+			toastStore.success(
+				'LPDF Imported',
+				`Loaded ${fileName} with all annotations restored`
+			);
+		} catch (error) {
+			console.error('Error loading annotations into stores:', error);
+			throw new Error(`Failed to load annotations: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		}
+	}
+
+	/**
+	 * Export .lpdf file using the existing file export system
+	 */
+	async exportLPDFFile(defaultFilename?: string): Promise<boolean> {
+		try {
+			const lpdfBytes = await this.exportToLPDF();
+			const filename = defaultFilename || this.getDefaultLPDFFilename();
+			
+			return await PDFExporter.exportFile(
+				lpdfBytes,
+				filename,
+				'application/zip' // .lpdf files are ZIP files
+			);
+		} catch (error) {
+			console.error('Error exporting .lpdf file:', error);
+			toastStore.error('Export Failed', `Could not create .lpdf file: ${error instanceof Error ? error.message : 'Unknown error'}`);
+			return false;
+		}
+	}
+
+	/**
+	 * Generate default filename for .lpdf export
+	 */
+	private getDefaultLPDFFilename(): string {
+		const baseName = this.currentFileName.replace('.pdf', '') || 'document';
+		const timestamp = new Date().toISOString().slice(0, 16).replace(/[:-]/g, '');
+		return `${baseName}_annotated_${timestamp}.lpdf`;
+	}
+
+	/**
+	 * Import .lpdf file and load it into the application
+	 */
+	static async importLPDFFile(lpdfFile: File): Promise<{ success: boolean; pdfFile?: File }> {
+		try {
+			// Parse the .lpdf file
+			const { pdfFile, annotations } = await LPDFExporter.importFromLPDF(lpdfFile);
+			
+			// Load the annotations into stores
+			await LPDFExporter.loadAnnotationsIntoStores(annotations, pdfFile.name, pdfFile.size);
+			
+			return { success: true, pdfFile };
+		} catch (error) {
+			console.error('Error importing .lpdf file:', error);
+			toastStore.error('Import Failed', `Could not load .lpdf file: ${error instanceof Error ? error.message : 'Unknown error'}`);
+			return { success: false };
+		}
+	}
+}
+
+// Convenience functions for easy usage
+export async function exportCurrentPDFAsLPDF(pdfBytes: Uint8Array, fileName: string = 'document.pdf'): Promise<boolean> {
+	const exporter = new LPDFExporter();
+	exporter.setOriginalPDF(pdfBytes, fileName);
+	return await exporter.exportLPDFFile();
+}
+
+export async function importLPDFFile(lpdfFile: File): Promise<{ success: boolean; pdfFile?: File }> {
+	return await LPDFExporter.importLPDFFile(lpdfFile);
+}

--- a/src/lib/utils/lpdfExport.ts
+++ b/src/lib/utils/lpdfExport.ts
@@ -1,4 +1,4 @@
-import JSZip from 'jszip';
+// JSZip will be dynamically imported when needed to reduce initial bundle size
 import type {
 	DrawingPath,
 	TextAnnotation,
@@ -274,6 +274,10 @@ export class LPDFExporter {
 		try {
 			console.log('Starting .lpdf export...');
 			
+			// Dynamically import JSZip to reduce initial bundle size
+			console.log('Loading JSZip...');
+			const JSZip = (await import('jszip')).default;
+			
 			// Force save all annotations to ensure we have the latest data
 			forceSaveAllAnnotations();
 			
@@ -325,11 +329,15 @@ export class LPDFExporter {
 		pdfFile: File;
 		annotations: LPDFAnnotationData;
 	}> {
-		try {
-			console.log('Starting .lpdf import...');
-			
-			// Read the ZIP file
-			const zip = await JSZip.loadAsync(lpdfFile);
+	try {
+		console.log('Starting .lpdf import...');
+		
+		// Dynamically import JSZip to reduce initial bundle size
+		console.log('Loading JSZip...');
+		const JSZip = (await import('jszip')).default;
+		
+		// Read the ZIP file
+		const zip = await JSZip.loadAsync(lpdfFile);
 			
 			// Extract original PDF
 			const pdfZipEntry = zip.file('original.pdf');

--- a/src/lib/utils/lpdfExport.ts
+++ b/src/lib/utils/lpdfExport.ts
@@ -338,7 +338,9 @@ export class LPDFExporter {
 			}
 			
 			const pdfBytes = await pdfZipEntry.async('uint8array');
-			const pdfFile = new File([pdfBytes.buffer as ArrayBuffer], 'document.pdf', { type: 'application/pdf' });
+			// Create a new Uint8Array to ensure proper typing and avoid potential ArrayBufferLike issues
+			const pdfUint8Array = new Uint8Array(pdfBytes);
+			const pdfFile = new File([pdfUint8Array], 'document.pdf', { type: 'application/pdf' });
 			
 			// Extract annotations
 			const annotationsZipEntry = zip.file('annotations.json');

--- a/src/lib/utils/pdfExport.ts
+++ b/src/lib/utils/pdfExport.ts
@@ -217,7 +217,8 @@ export class PDFExporter {
 			'application/pdf': 'PDF Documents',
 			'image/png': 'PNG Images',
 			'image/jpeg': 'JPEG Images',
-			'image/webp': 'WebP Images'
+			'image/webp': 'WebP Images',
+			'application/zip': 'LPDF Files'
 		};
 		return filterNames[mimeType] || 'All Files';
 	}
@@ -244,7 +245,8 @@ export class PDFExporter {
 			'application/pdf': '.pdf',
 			'image/png': '.png',
 			'image/jpeg': '.jpg',
-			'image/webp': '.webp'
+			'image/webp': '.webp',
+			'application/zip': '.lpdf'
 		};
 		return extensions[mimeType] || '.bin';
 	}

--- a/src/lib/utils/pdfUtils.ts
+++ b/src/lib/utils/pdfUtils.ts
@@ -340,6 +340,13 @@ export function isValidMarkdownFile(file: File): boolean {
 	return validExtensions.some((ext) => fileName.endsWith(ext));
 }
 
+// Utility function to validate LPDF file
+export function isValidLPDFFile(file: File): boolean {
+	// Check file extension (LPDF files should end with .lpdf)
+	const fileName = file.name.toLowerCase();
+	return fileName.endsWith('.lpdf');
+}
+
 // Utility function to format file size
 export function formatFileSize(bytes: number): string {
 	if (bytes === 0) return '0 Bytes';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1217,7 +1217,7 @@
 <!-- Hidden file input -->
 <input
   type="file"
-  accept=".pdf,.md,.markdown,.lpdf,application/pdf,text/markdown"
+  accept=".pdf,.lpdf,.md,.markdown"
   multiple={false}
   class="hidden"
   on:change={(event) => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -118,6 +118,13 @@
         if (result.success && result.pdfFile) {
           console.log('🎉 LPDF imported successfully, loading PDF...');
           
+          // Validate extracted PDF size to prevent bypass of upload size limits
+          if (result.pdfFile.size > MAX_FILE_SIZE) {
+            console.log('Extracted PDF too large:', result.pdfFile.size);
+            toastStore.error('Extracted PDF Too Large', `The PDF inside the LPDF file (${(result.pdfFile.size / (1024 * 1024)).toFixed(1)}MB) exceeds the maximum limit of ${(MAX_FILE_SIZE / (1024 * 1024))}MB.`);
+            return;
+          }
+          
           // Store the extracted PDF file and navigate like a normal PDF upload
           const storeResult = await storeUploadedFile(result.pdfFile);
           

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,7 +28,8 @@
   import { isTauri } from '$lib/utils/tauriUtils';
   import { getFormattedVersion } from '$lib/utils/version';
   import { PDFExporter } from '$lib/utils/pdfExport';
-  import { createBlankPDF, isValidMarkdownFile, isValidPDFFile } from '$lib/utils/pdfUtils';
+  import { exportCurrentPDFAsLPDF, importLPDFFile } from '$lib/utils/lpdfExport';
+  import { createBlankPDF, isValidMarkdownFile, isValidPDFFile, isValidLPDFFile } from '$lib/utils/pdfUtils';
   import { convertMarkdownToPDF, readMarkdownFile } from '$lib/utils/markdownUtils';
 
   let pdfViewer: PDFViewer;
@@ -91,13 +92,14 @@
       return;
     }
 
-    // Check if it's a PDF or Markdown file
+    // Check if it's a PDF, Markdown, or LPDF file
     const isPDF = isValidPDFFile(file);
     const isMarkdown = isValidMarkdownFile(file);
+    const isLPDF = isValidLPDFFile(file);
     
-    if (!isPDF && !isMarkdown) {
+    if (!isPDF && !isMarkdown && !isLPDF) {
       console.log('Invalid file type');
-      toastStore.error('Invalid File', 'Please choose a valid PDF or Markdown file.');
+      toastStore.error('Invalid File', 'Please choose a valid PDF, Markdown, or LPDF file.');
       return;
     }
 
@@ -105,6 +107,34 @@
     if (file.size > MAX_FILE_SIZE) {
       console.log('File too large');
       toastStore.error('File Too Large', `File size (${(file.size / (1024 * 1024)).toFixed(1)}MB) exceeds the maximum limit of ${(MAX_FILE_SIZE / (1024 * 1024))}MB.`);
+      return;
+    }
+
+    // If it's an LPDF file, import it and treat the extracted PDF like a normal PDF upload
+    if (isLPDF) {
+      console.log('LPDF file detected, importing...');
+      try {
+        const result = await importLPDFFile(file);
+        if (result.success && result.pdfFile) {
+          console.log('🎉 LPDF imported successfully, loading PDF...');
+          
+          // Store the extracted PDF file and navigate like a normal PDF upload
+          const storeResult = await storeUploadedFile(result.pdfFile);
+          
+          if (storeResult.success && storeResult.id) {
+            console.log('Extracted PDF stored successfully, navigating to pdf-upload with ID:', storeResult.id);
+            goto(`/pdf-upload?fileId=${storeResult.id}`);
+          } else {
+            console.error('Failed to store extracted PDF:', storeResult.error);
+            toastStore.error('Storage Error', 'Failed to load the PDF from LPDF file.');
+          }
+        } else {
+          console.log('❌ LPDF import failed or was cancelled');
+        }
+      } catch (error) {
+        console.error('LPDF import failed:', error);
+        toastStore.error('Import Failed', 'LPDF import failed. Please try again.');
+      }
       return;
     }
 
@@ -746,6 +776,44 @@
     }
   }
 
+  async function handleExportLPDF() {
+    if (!currentFile || !pdfViewer) {
+      toastStore.warning('No PDF', 'No PDF to export');
+      return;
+    }
+
+    try {
+      let pdfBytes: Uint8Array;
+      let originalName: string;
+
+      if (typeof currentFile === 'string') {
+        console.log('Fetching PDF data from URL for LPDF export:', currentFile);
+        const response = await fetch(currentFile);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch PDF: ${response.statusText}`);
+        }
+        const arrayBuffer = await response.arrayBuffer();
+        pdfBytes = new Uint8Array(arrayBuffer);
+        originalName = extractFilenameFromUrl(currentFile).replace(/\.pdf$/i, '');
+      } else {
+        const arrayBuffer = await currentFile.arrayBuffer();
+        pdfBytes = new Uint8Array(arrayBuffer);
+        originalName = currentFile.name.replace(/\.pdf$/i, '');
+      }
+
+      const success = await exportCurrentPDFAsLPDF(pdfBytes, `${originalName}.pdf`);
+      if (success) {
+        console.log('🎉 LPDF exported successfully');
+      } else {
+        console.log('📄 LPDF export was cancelled by user');
+      }
+    } catch (error) {
+      console.error('LPDF export failed:', error);
+      toastStore.error('Export Failed', 'LPDF export failed. Please try again.');
+    }
+  }
+
+
   function handleToggleThumbnails(show: boolean) {
     showThumbnails = show;
   }
@@ -958,6 +1026,7 @@
       onFitToWidth={() => pdfViewer?.fitToWidth()}
       onFitToHeight={() => pdfViewer?.fitToHeight()}
       onExportPDF={handleExportPDF}
+      onExportLPDF={handleExportLPDF}
       {showThumbnails}
       onToggleThumbnails={handleToggleThumbnails}
     />
@@ -1098,7 +1167,7 @@
             {/if}
 
             <p class="text-base sm:text-lg text-slate dark:text-gray-300 font-medium hidden sm:block">
-              or drop a PDF or Markdown file anywhere
+              or drop a PDF, Markdown, or LPDF file anywhere
             </p>
           </div>
 
@@ -1148,7 +1217,7 @@
 <!-- Hidden file input -->
 <input
   type="file"
-  accept=".pdf,.md,.markdown,application/pdf,text/markdown"
+  accept=".pdf,.md,.markdown,.lpdf,application/pdf,text/markdown"
   multiple={false}
   class="hidden"
   on:change={(event) => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1174,7 +1174,7 @@
             {/if}
 
             <p class="text-base sm:text-lg text-slate dark:text-gray-300 font-medium hidden sm:block">
-              or drop a PDF, Markdown, or LPDF file anywhere
+              or drop a PDF or Markdown file anywhere
             </p>
           </div>
 

--- a/src/routes/pdf-upload/+page.svelte
+++ b/src/routes/pdf-upload/+page.svelte
@@ -204,6 +204,13 @@
       return;
     }
 
+    // Check file size for all file types before processing
+    if (file.size > MAX_FILE_SIZE) {
+      console.log('File too large');
+      toastStore.error('File Too Large', `File size (${(file.size / (1024 * 1024)).toFixed(1)}MB) exceeds the maximum limit of ${(MAX_FILE_SIZE / (1024 * 1024))}MB.`);
+      return;
+    }
+
     // If it's an LPDF file, import it and set the extracted PDF as currentFile
     if (isLPDF) {
       console.log('LPDF file detected, importing...');
@@ -226,12 +233,6 @@
         console.error('LPDF import failed:', error);
         toastStore.error('Import Failed', 'LPDF import failed. Please try again.');
       }
-      return;
-    }
-
-    if (file.size > MAX_FILE_SIZE) { // 50MB limit
-      console.log('File too large');
-      toastStore.error('File Too Large', 'File too large. Please choose a file under 50MB.');
       return;
     }
 

--- a/src/routes/pdf-upload/+page.svelte
+++ b/src/routes/pdf-upload/+page.svelte
@@ -910,7 +910,7 @@
 <!-- Hidden file input -->
 <input
   type="file"
-  accept=".pdf,.md,.markdown,.lpdf,application/pdf,text/markdown"
+  accept=".pdf,.lpdf,.md,.markdown"
   multiple={false}
   class="hidden"
   on:change={(event) => {

--- a/src/routes/pdf/[url]/+page.svelte
+++ b/src/routes/pdf/[url]/+page.svelte
@@ -14,10 +14,11 @@
 	import PageThumbnails from '$lib/components/PageThumbnails.svelte';
 	import HelpButton from '$lib/components/HelpButton.svelte';
 	import HomeButton from '$lib/components/HomeButton.svelte';
-	import { isValidPDFFile } from '$lib/utils/pdfUtils';
+	import { isValidPDFFile, isValidLPDFFile } from '$lib/utils/pdfUtils';
 	import { forceSaveAllAnnotations, pdfState, redo, setCurrentPDF, setTool, undo } from '$lib/stores/drawingStore';
 	import { toastStore } from '$lib/stores/toastStore';
 	import { PDFExporter } from '$lib/utils/pdfExport';
+	import { exportCurrentPDFAsLPDF, importLPDFFile } from '$lib/utils/lpdfExport';
 	import { MAX_FILE_SIZE } from '$lib/constants';
 	import { isTauri } from '$lib/utils/tauriUtils';
 
@@ -125,14 +126,36 @@
     }
   }
 
-  function handleFileUpload(files: FileList) {
+  async function handleFileUpload(files: FileList) {
     console.log('handleFileUpload called with:', files);
     const file = files[0];
     console.log('Selected file:', file?.name, 'Type:', file?.type, 'Size:', file?.size);
 
-    if (!isValidPDFFile(file)) {
-      console.log('Invalid PDF file');
-      toastStore.error('Invalid File', 'Please choose a valid PDF file.');
+    const isPDF = isValidPDFFile(file);
+    const isLPDF = isValidLPDFFile(file);
+
+    if (!isPDF && !isLPDF) {
+      console.log('Invalid file type');
+      toastStore.error('Invalid File', 'Please choose a valid PDF or LPDF file.');
+      return;
+    }
+
+    // If it's an LPDF file, import it directly
+    if (isLPDF) {
+      console.log('LPDF file detected, importing...');
+      try {
+        const success = await importLPDFFile(file);
+        if (success) {
+          console.log('🎉 LPDF imported successfully');
+          // Force refresh to show imported content
+          window.location.reload();
+        } else {
+          console.log('❌ LPDF import failed or was cancelled');
+        }
+      } catch (error) {
+        console.error('LPDF import failed:', error);
+        toastStore.error('Import Failed', 'LPDF import failed. Please try again.');
+      }
       return;
     }
 
@@ -717,6 +740,48 @@
     }
   }
 
+  async function handleExportLPDF() {
+    if (!currentFile || !pdfViewer) {
+      toastStore.warning('No PDF', 'No PDF to export');
+      return;
+    }
+
+    try {
+      // Force save all annotations to localStorage before export
+      forceSaveAllAnnotations();
+      console.log('✅ All annotations force-saved to localStorage before export');
+
+      let pdfBytes: Uint8Array;
+      let originalName: string;
+
+      if (typeof currentFile === 'string') {
+        console.log('Fetching PDF data from URL for LPDF export:', currentFile);
+        const response = await fetch(currentFile);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch PDF: ${response.statusText}`);
+        }
+        const arrayBuffer = await response.arrayBuffer();
+        pdfBytes = new Uint8Array(arrayBuffer);
+        originalName = extractFilenameFromUrl(currentFile).replace(/\.pdf$/i, '');
+      } else {
+        const arrayBuffer = await currentFile.arrayBuffer();
+        pdfBytes = new Uint8Array(arrayBuffer);
+        originalName = currentFile.name.replace(/\.pdf$/i, '');
+      }
+
+      const success = await exportCurrentPDFAsLPDF(pdfBytes, `${originalName}.pdf`);
+      if (success) {
+        console.log('🎉 LPDF exported successfully');
+      } else {
+        console.log('📄 LPDF export was cancelled by user');
+      }
+    } catch (error) {
+      console.error('LPDF export failed:', error);
+      toastStore.error('Export Failed', 'LPDF export failed. Please try again.');
+    }
+  }
+
+
   function handleToggleThumbnails(show: boolean) {
     showThumbnails = show;
   }
@@ -759,6 +824,7 @@
         onFitToWidth={() => pdfViewer?.fitToWidth()}
         onFitToHeight={() => pdfViewer?.fitToHeight()}
         onExportPDF={handleExportPDF}
+        onExportLPDF={handleExportLPDF}
         {showThumbnails}
         onToggleThumbnails={handleToggleThumbnails}
       />
@@ -818,7 +884,7 @@
 <!-- Hidden file input -->
 <input
   type="file"
-  accept=".pdf,application/pdf"
+  accept=".pdf,.lpdf,application/pdf"
   multiple={false}
   class="hidden"
   on:change={(event) => {

--- a/src/routes/pdf/[url]/+page.svelte
+++ b/src/routes/pdf/[url]/+page.svelte
@@ -140,15 +140,29 @@
       return;
     }
 
-    // If it's an LPDF file, import it directly
+    // If it's an LPDF file, import it and navigate to pdf-upload with the extracted PDF
     if (isLPDF) {
       console.log('LPDF file detected, importing...');
       try {
-        const success = await importLPDFFile(file);
-        if (success) {
-          console.log('🎉 LPDF imported successfully');
-          // Force refresh to show imported content
-          window.location.reload();
+        const result = await importLPDFFile(file);
+        if (result.success && result.pdfFile) {
+          console.log('🎉 LPDF imported successfully, navigating to pdf-upload...');
+          
+          // Store the extracted PDF file and navigate to pdf-upload route (like main route does)
+          const fileReader = new FileReader();
+          fileReader.onload = (e) => {
+            const arrayBuffer = e.target?.result as ArrayBuffer;
+            const fileData = {
+              name: result.pdfFile!.name,
+              size: result.pdfFile!.size,
+              type: result.pdfFile!.type,
+              data: Array.from(new Uint8Array(arrayBuffer))
+            };
+            sessionStorage.setItem('tempPdfFile', JSON.stringify(fileData));
+            console.log('Extracted PDF stored in sessionStorage, navigating...');
+            goto('/pdf-upload');
+          };
+          fileReader.readAsArrayBuffer(result.pdfFile);
         } else {
           console.log('❌ LPDF import failed or was cancelled');
         }

--- a/src/routes/pdf/[url]/+page.svelte
+++ b/src/routes/pdf/[url]/+page.svelte
@@ -898,7 +898,7 @@
 <!-- Hidden file input -->
 <input
   type="file"
-  accept=".pdf,.lpdf,application/pdf"
+  accept=".pdf,.lpdf,.md,.markdown"
   multiple={false}
   class="hidden"
   on:change={(event) => {

--- a/src/routes/pdf/[url]/+page.svelte
+++ b/src/routes/pdf/[url]/+page.svelte
@@ -140,6 +140,13 @@
       return;
     }
 
+    // Check file size for all file types before processing
+    if (file.size > MAX_FILE_SIZE) {
+      console.log('File too large');
+      toastStore.error('File Too Large', 'File too large. Please choose a file under 50MB.');
+      return;
+    }
+
     // If it's an LPDF file, import it and navigate to pdf-upload with the extracted PDF
     if (isLPDF) {
       console.log('LPDF file detected, importing...');
@@ -170,12 +177,6 @@
         console.error('LPDF import failed:', error);
         toastStore.error('Import Failed', 'LPDF import failed. Please try again.');
       }
-      return;
-    }
-
-    if (file.size > MAX_FILE_SIZE) { // 50MB limit
-      console.log('File too large');
-      toastStore.error('File Too Large', 'File too large. Please choose a file under 50MB.');
       return;
     }
 

--- a/src/routes/templates/[templateName]/+page.svelte
+++ b/src/routes/templates/[templateName]/+page.svelte
@@ -125,6 +125,13 @@
 
     // If it's an LPDF file, import it and navigate to pdf-upload with the extracted PDF
     if (isLPDF) {
+      // Check file size for LPDF files too
+      if (file.size > MAX_FILE_SIZE) {
+        console.log('LPDF file too large');
+        toastStore.error('File Too Large', `File size (${(file.size / (1024 * 1024)).toFixed(1)}MB) exceeds the maximum limit of ${(MAX_FILE_SIZE / (1024 * 1024))}MB.`);
+        return;
+      }
+      
       console.log('LPDF file detected, importing...');
       try {
         const result = await importLPDFFile(file);

--- a/src/routes/templates/[templateName]/+page.svelte
+++ b/src/routes/templates/[templateName]/+page.svelte
@@ -123,15 +123,29 @@
       return;
     }
 
-    // If it's an LPDF file, import it directly
+    // If it's an LPDF file, import it and navigate to pdf-upload with the extracted PDF
     if (isLPDF) {
       console.log('LPDF file detected, importing...');
       try {
-        const success = await importLPDFFile(file);
-        if (success) {
-          console.log('🎉 LPDF imported successfully');
-          // Force refresh to show imported content
-          window.location.reload();
+        const result = await importLPDFFile(file);
+        if (result.success && result.pdfFile) {
+          console.log('🎉 LPDF imported successfully, navigating to pdf-upload...');
+          
+          // Store the extracted PDF file and navigate to pdf-upload route (like main route does)
+          const fileReader = new FileReader();
+          fileReader.onload = (e) => {
+            const arrayBuffer = e.target?.result as ArrayBuffer;
+            const fileData = {
+              name: result.pdfFile!.name,
+              size: result.pdfFile!.size,
+              type: result.pdfFile!.type,
+              data: Array.from(new Uint8Array(arrayBuffer))
+            };
+            sessionStorage.setItem('tempPdfFile', JSON.stringify(fileData));
+            console.log('Extracted PDF stored in sessionStorage, navigating...');
+            goto('/pdf-upload');
+          };
+          fileReader.readAsArrayBuffer(result.pdfFile);
         } else {
           console.log('❌ LPDF import failed or was cancelled');
         }


### PR DESCRIPTION
…annotations

- Add JSZip dependency for creating and reading ZIP-based LPDF files
- Create LPDFExporter class for bundling original PDF + annotations as .lpdf format
- Add isValidLPDFFile validation function for LPDF file detection
- Integrate LPDF import into standard file upload workflow (main route working)
- Update file inputs to accept .lpdf files alongside PDF and Markdown
- Remove separate LPDF import buttons - now uses unified file selection
- LPDF files automatically extract PDF and restore all annotation data
- Export functionality remains available in download menu as 'Export as LPDF'
- Main route (/) fully functional with seamless LPDF import/export workflow

The .lpdf format is a ZIP file containing:
- original.pdf (source PDF bytes)
- annotations.json (complete annotation data from all stores)

This enables portable, self-contained files with PDF + annotations that can be shared and imported seamlessly across sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Full LPDF support: import restores PDF + annotations; export packages PDF+annotations as LPDF. Toolbar now offers LPDF export alongside PDF.

- **UI**
  - Drag/drop prompts, file pickers, desktop export menu and mobile menus updated to include LPDF and adjusted wording/flows.

- **Utilities**
  - LPDF validation and size/security limits added; import/export workflows with user feedback and error handling.

- **Chores**
  - Added jszip dependency and bumped app version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->