### PR TITLE
fix: repair stylus drawing on tablets and trackpad pinch-zoom via pointer event migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "leedpdf",
 	"private": true,
-	"version": "2.33.0",
+	"version": "2.34.0",
 	"type": "module",
 	"packageManager": "pnpm@10.32.1",
 	"scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2551,7 +2551,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leed-pdf"
-version = "2.33.0"
+version = "2.34.0"
 dependencies = [
  "font-kit",
  "image",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "leed-pdf"
-version = "2.33.0"
+version = "2.34.0"
 description = "A Lightweight, Opensource and Private PDF Viewer & Annotation Tool"
-authors = ["Rudi K <reach@rudi.engineer>"]
+authors = ["Rudi K <write@leed.my>"]
 license = "AGPL"
 repository = "https://github.com/rudi-q/leed_pdf_viewer"
 edition = "2021"

--- a/src/lib/components/ArrowOverlay.svelte
+++ b/src/lib/components/ArrowOverlay.svelte
@@ -32,7 +32,7 @@
 	let startX = 0;
 	let startY = 0;
 
-	const handleContainerMouseDown = (event: MouseEvent) => {
+	const handleContainerPointerDown = (event: PointerEvent) => {
 		if (!isArrowTool || viewOnlyMode) return;
 
 		// Don't create new arrows if clicking on existing arrow elements
@@ -46,6 +46,9 @@
 
 		event.preventDefault();
 		event.stopPropagation();
+
+		// Capture pointer so events keep routing here even if pointer leaves the element
+		overlayElement.setPointerCapture(event.pointerId);
 
 		const rect = overlayElement.getBoundingClientRect();
 		// Get click position in current scale
@@ -67,8 +70,8 @@
 		startY = basePoint.y;
 
 		isCreatingArrow = true;
-		document.addEventListener('mousemove', handleDocumentMouseMove);
-		document.addEventListener('mouseup', handleDocumentMouseUp);
+		// setPointerCapture (above) already routes all pointermove/pointerup back here —
+		// no document-level listeners needed.
 
 		// Create new arrow immediately (storing at base scale)
 		const newArrow: ArrowAnnotation = {
@@ -93,9 +96,9 @@
 		addArrowAnnotation(newArrow);
 	};
 
-	// Shared helper for transforming mouse event to base scale coordinates
+	// Shared helper for transforming pointer event to base scale coordinates
 	// and updating the arrow's end point.
-	const computeAndUpdateArrowEnd = (event: MouseEvent) => {
+	const computeAndUpdateArrowEnd = (event: PointerEvent) => {
 		const targetArrow = $currentPageArrowAnnotations[$currentPageArrowAnnotations.length - 1];
 		if (targetArrow && overlayElement) {
 			const rect = overlayElement.getBoundingClientRect();
@@ -131,33 +134,18 @@
 		}
 	};
 
-	const handleContainerMouseMove = (event: MouseEvent) => {
+	const handleContainerPointerMove = (event: PointerEvent) => {
 		if (!isCreatingArrow) return;
 		computeAndUpdateArrowEnd(event);
 	};
 
-	const handleContainerMouseUp = (event: MouseEvent) => {
-		if (isCreatingArrow) {
-			isCreatingArrow = false;
-			// Clean up document event listeners
-			document.removeEventListener('mousemove', handleDocumentMouseMove);
-			document.removeEventListener('mouseup', handleDocumentMouseUp);
-		}
+	const handleContainerPointerUp = (event: PointerEvent) => {
+		isCreatingArrow = false;
 	};
 
-	// Document-level mouse handlers for better tracking during arrow creation
-	const handleDocumentMouseMove = (event: MouseEvent) => {
-		if (!isCreatingArrow || !overlayElement) return;
-		computeAndUpdateArrowEnd(event);
-	};
-
-	const handleDocumentMouseUp = (event: MouseEvent) => {
-		if (isCreatingArrow) {
-			isCreatingArrow = false;
-			// Clean up document event listeners
-			document.removeEventListener('mousemove', handleDocumentMouseMove);
-			document.removeEventListener('mouseup', handleDocumentMouseUp);
-		}
+	// Also cancel arrow creation if pointer capture is lost (e.g. browser interruption)
+	const handleContainerPointerCancel = () => {
+		isCreatingArrow = false;
 	};
 
 	// Handle arrow update event from child components
@@ -175,12 +163,8 @@
 		// and will be displayed at current scale automatically
 	});
 
-	// Clean up event listeners on destroy
 	onDestroy(() => {
-		if (isCreatingArrow) {
-			document.removeEventListener('mousemove', handleDocumentMouseMove);
-			document.removeEventListener('mouseup', handleDocumentMouseUp);
-		}
+		// pointer capture is automatically released when the element is removed from the DOM
 	});
 
 	// Update cursor style based on tool
@@ -201,10 +185,11 @@
 <div
 	bind:this={overlayElement}
 	class="arrow-overlay absolute top-0 left-0 {pointerEventsClass}"
-	style="width: {containerWidth}px; height: {containerHeight}px; z-index: 3;"
-	on:mousedown={handleContainerMouseDown}
-	on:mousemove={handleContainerMouseMove}
-	on:mouseup={handleContainerMouseUp}
+	style="width: {containerWidth}px; height: {containerHeight}px; z-index: 3; touch-action: none;"
+	on:pointerdown={handleContainerPointerDown}
+	on:pointermove={handleContainerPointerMove}
+	on:pointerup={handleContainerPointerUp}
+	on:pointercancel={handleContainerPointerCancel}
 	role="application"
 	aria-label="Arrow annotations area"
 	data-arrow-overlay="true"
@@ -227,6 +212,7 @@
 <style>
 	.arrow-overlay {
 		background: transparent;
+		touch-action: none;
 	}
 
 	.pointer-events-auto {

--- a/src/lib/components/ArrowOverlay.svelte
+++ b/src/lib/components/ArrowOverlay.svelte
@@ -24,6 +24,7 @@
 	let overlayElement: HTMLDivElement;
 
 	let isCreatingArrow = false;
+	let activePointerId: number | null = null;
 
 	// Flags whether the arrow tool is active
 	$: isArrowTool = $drawingState.tool === 'arrow';
@@ -34,6 +35,7 @@
 
 	const handleContainerPointerDown = (event: PointerEvent) => {
 		if (!isArrowTool || viewOnlyMode) return;
+		if (isCreatingArrow) return;
 
 		// Don't create new arrows if clicking on existing arrow elements
 		const target = event.target as Element;
@@ -41,12 +43,10 @@
 			return;
 		}
 
-		// Reset flag to ensure we can create multiple arrows
-		isCreatingArrow = false;
-
 		event.preventDefault();
 		event.stopPropagation();
 
+		activePointerId = event.pointerId;
 		// Capture pointer so events keep routing here even if pointer leaves the element
 		overlayElement.setPointerCapture(event.pointerId);
 
@@ -135,17 +135,21 @@
 	};
 
 	const handleContainerPointerMove = (event: PointerEvent) => {
-		if (!isCreatingArrow) return;
+		if (!isCreatingArrow || event.pointerId !== activePointerId) return;
 		computeAndUpdateArrowEnd(event);
 	};
 
 	const handleContainerPointerUp = (event: PointerEvent) => {
+		if (event.pointerId !== activePointerId) return;
 		isCreatingArrow = false;
+		activePointerId = null;
 	};
 
 	// Also cancel arrow creation if pointer capture is lost (e.g. browser interruption)
-	const handleContainerPointerCancel = () => {
+	const handleContainerPointerCancel = (event: PointerEvent) => {
+		if (event.pointerId !== activePointerId) return;
 		isCreatingArrow = false;
+		activePointerId = null;
 	};
 
 	// Handle arrow update event from child components

--- a/src/lib/components/PDFViewer.svelte
+++ b/src/lib/components/PDFViewer.svelte
@@ -362,6 +362,11 @@
 			pinchRafId = null;
 		}
 
+		if (wheelZoomDebounceId !== null) {
+			clearTimeout(wheelZoomDebounceId);
+			wheelZoomDebounceId = null;
+		}
+
 		if (pdfManager) {
 			pdfManager.destroy();
 		}

--- a/src/lib/components/PDFViewer.svelte
+++ b/src/lib/components/PDFViewer.svelte
@@ -132,6 +132,11 @@
 	let isPinching = false;
 	const PAN_THRESHOLD = 5; // px dead zone before pan activates
 	let isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0;
+	let wheelZoomDebounceId: ReturnType<typeof setTimeout> | null = null;
+	let wheelGestureBaseScale = 1;   // rendered scale at gesture start (CSS scale denominator)
+	let wheelAccumulatedScale = 1;   // accumulated logical scale during gesture (avoids reading reactive pdfState mid-gesture)
+	let wheelCurrentPanX = 0;        // accumulated pan X during gesture (avoids writing reactive panOffset mid-gesture)
+	let wheelCurrentPanY = 0;
 
 	// Eraser gesture modifier: Alt for partial erase
 	let isAltEraseMode = false;
@@ -1133,6 +1138,10 @@
 	}
 
 	function handleContainerPointerDown(event: PointerEvent) {
+		// Stylus events that aren't captured by the freehand overlay should not
+		// feed the gesture tracker or trigger pan — let the overlay handle them.
+		if (event.pointerType === 'pen' && !hasActiveFreehandTool()) return;
+
 		if (gestureTracker) gestureTracker.track(event);
 		if (panInertia) panInertia.cancel();
 
@@ -1412,14 +1421,59 @@
 		if (!containerDiv?.contains(event.target as Node)) return;
 
 		if (event.ctrlKey) {
-			// Ctrl + scroll = zoom
+			// Ctrl + scroll (or trackpad pinch) = smooth continuous zoom anchored to cursor.
+			//
+			// IMPORTANT: we deliberately avoid writing to reactive `panOffset` or calling
+			// `pdfState.update()` during the gesture. Any reactive write triggers a Svelte
+			// re-render which resets contentWrapperDiv.style.transform back to the
+			// template's translate-only value, destroying the CSS scale. We mirror the
+			// touch-pinch pattern: accumulate in local vars, commit only on gesture end.
 			event.preventDefault();
 
-			if (event.deltaY < 0) {
-				zoomIn();
-			} else {
-				zoomOut();
+			// First event of this gesture — snapshot state so we never read reactive
+			// stores mid-gesture.
+			if (wheelZoomDebounceId === null) {
+				wheelGestureBaseScale = $pdfState.scale;
+				wheelAccumulatedScale = $pdfState.scale;
+				wheelCurrentPanX = panOffset.x;
+				wheelCurrentPanY = panOffset.y;
 			}
+
+			const prevScale = wheelAccumulatedScale;
+			const factor = Math.pow(0.999, event.deltaY);
+			wheelAccumulatedScale = Math.max(0.1, Math.min(10, prevScale * factor));
+
+			// Cursor-anchored pan: keep the document point under the cursor fixed.
+			const rect = containerDiv.getBoundingClientRect();
+			const cursorX = event.clientX - rect.left;
+			const cursorY = event.clientY - rect.top;
+			wheelCurrentPanX = cursorX - (cursorX - wheelCurrentPanX) * (wheelAccumulatedScale / prevScale);
+			wheelCurrentPanY = cursorY - (cursorY - wheelCurrentPanY) * (wheelAccumulatedScale / prevScale);
+
+			// Apply visual scale immediately — no reactive writes so Svelte won't
+			// override this transform until we commit at gesture end.
+			const cssScale = wheelAccumulatedScale / wheelGestureBaseScale;
+			if (contentWrapperDiv) {
+				contentWrapperDiv.style.transform = `translate(${wheelCurrentPanX}px, ${wheelCurrentPanY}px) scale(${cssScale})`;
+			}
+
+			// Debounce the expensive canvas re-render; commit reactive state only then.
+			if (wheelZoomDebounceId !== null) clearTimeout(wheelZoomDebounceId);
+			wheelZoomDebounceId = setTimeout(async () => {
+				wheelZoomDebounceId = null;
+				const finalScale = wheelAccumulatedScale;
+				const finalPanX = wheelCurrentPanX;
+				const finalPanY = wheelCurrentPanY;
+				// Commit pan first so the template re-render uses the correct position.
+				panOffset = { x: finalPanX, y: finalPanY };
+				await renderCurrentPage(finalScale);
+				wheelGestureBaseScale = finalScale;
+				// Reset to translate-only — canvas is now rendered at the correct scale.
+				if (contentWrapperDiv) {
+					contentWrapperDiv.style.transform = `translate(${finalPanX}px, ${finalPanY}px)`;
+				}
+				pdfState.update((s) => ({ ...s, scale: finalScale }));
+			}, 80);
 			return;
 		}
 

--- a/src/lib/components/PDFViewer.svelte
+++ b/src/lib/components/PDFViewer.svelte
@@ -1465,7 +1465,7 @@
 			// Debounce the expensive canvas re-render; commit reactive state only then.
 			if (wheelZoomDebounceId !== null) clearTimeout(wheelZoomDebounceId);
 			wheelZoomDebounceId = setTimeout(async () => {
-				wheelZoomDebounceId = null;
+				const myDebounceId = wheelZoomDebounceId;
 				const finalScale = wheelAccumulatedScale;
 				const finalPanX = wheelCurrentPanX;
 				const finalPanY = wheelCurrentPanY;
@@ -1478,6 +1478,7 @@
 					contentWrapperDiv.style.transform = `translate(${finalPanX}px, ${finalPanY}px)`;
 				}
 				pdfState.update((s) => ({ ...s, scale: finalScale }));
+				if (wheelZoomDebounceId === myDebounceId) wheelZoomDebounceId = null;
 			}, 80);
 			return;
 		}

--- a/src/lib/components/PDFViewer.svelte
+++ b/src/lib/components/PDFViewer.svelte
@@ -667,8 +667,13 @@
 		}
 	}
 
-	async function renderCurrentPage(newScale?: number) {
-		if (!pdfCanvas || !$pdfState.document || isRendering) return;
+	// Returns false ONLY when the render was skipped because another render is already
+	// in flight (isRendering). Callers needing a guaranteed paint — the wheel-zoom
+	// commit — retry on false. Any other outcome (rendered, errored, or nothing to
+	// render) returns true so those callers don't retry indefinitely.
+	async function renderCurrentPage(newScale?: number): Promise<boolean> {
+		if (!pdfCanvas || !$pdfState.document) return true;
+		if (isRendering) return false;
 
 		isRendering = true;
 		try {
@@ -787,8 +792,10 @@
 				console.warn('Could not extract link annotations:', linkError);
 				pageLinks = [];
 			}
+			return true;
 		} catch (error) {
 			console.error('Error rendering page:', error);
+			return true;
 		} finally {
 			isRendering = false;
 			
@@ -1552,6 +1559,40 @@
 		scrollByDelta(-ARROW_KEY_SCROLL_PX);
 	}
 
+	// Commit the accumulated Ctrl+wheel zoom: re-render the canvas crisply at the final
+	// scale, then swap the live CSS-scaled transform for the plain translate. Scheduled
+	// (and re-scheduled on retry) via wheelZoomDebounceId.
+	async function commitWheelZoom() {
+		const myDebounceId = wheelZoomDebounceId;
+		const finalScale = wheelAccumulatedScale;
+		const finalPanX = wheelCurrentPanX;
+		const finalPanY = wheelCurrentPanY;
+		// Commit pan first so the template re-render uses the correct position.
+		panOffset = { x: finalPanX, y: finalPanY };
+		const rendered = await renderCurrentPage(finalScale);
+		// A newer gesture (or a reset) may have replaced this commit while the render
+		// was in flight — bail so we don't clobber its accumulated state.
+		if (wheelZoomDebounceId !== myDebounceId) return;
+		if (!rendered) {
+			// Another render was in progress, so ours was skipped and the canvas is
+			// still at the old scale. Re-apply the visual CSS scale so the view stays
+			// correctly zoomed, then retry — never commit a scale we didn't paint.
+			const cssScale = finalScale / wheelGestureBaseScale;
+			if (contentWrapperDiv) {
+				contentWrapperDiv.style.transform = `translate(${finalPanX}px, ${finalPanY}px) scale(${cssScale})`;
+			}
+			wheelZoomDebounceId = setTimeout(commitWheelZoom, 80);
+			return;
+		}
+		wheelGestureBaseScale = finalScale;
+		// Reset to translate-only — canvas is now rendered at the correct scale.
+		if (contentWrapperDiv) {
+			contentWrapperDiv.style.transform = `translate(${finalPanX}px, ${finalPanY}px)`;
+		}
+		pdfState.update((s) => ({ ...s, scale: finalScale }));
+		wheelZoomDebounceId = null;
+	}
+
 	function handleWheel(event: WheelEvent) {
 		// Only handle wheel events that originate inside the PDF container.
 		// This prevents blocking scrolling on toolbar, thumbnails, modals, etc.
@@ -1601,25 +1642,7 @@
 
 			// Debounce the expensive canvas re-render; commit reactive state only then.
 			if (wheelZoomDebounceId !== null) clearTimeout(wheelZoomDebounceId);
-			wheelZoomDebounceId = setTimeout(async () => {
-				const myDebounceId = wheelZoomDebounceId;
-				const finalScale = wheelAccumulatedScale;
-				const finalPanX = wheelCurrentPanX;
-				const finalPanY = wheelCurrentPanY;
-				// Commit pan first so the template re-render uses the correct position.
-				panOffset = { x: finalPanX, y: finalPanY };
-				await renderCurrentPage(finalScale);
-				// A newer gesture may have started while the render was in flight — bail
-				// out to avoid clobbering its accumulated state.
-				if (wheelZoomDebounceId !== myDebounceId) return;
-				wheelGestureBaseScale = finalScale;
-				// Reset to translate-only — canvas is now rendered at the correct scale.
-				if (contentWrapperDiv) {
-					contentWrapperDiv.style.transform = `translate(${finalPanX}px, ${finalPanY}px)`;
-				}
-				pdfState.update((s) => ({ ...s, scale: finalScale }));
-				wheelZoomDebounceId = null;
-			}, 80);
+			wheelZoomDebounceId = setTimeout(commitWheelZoom, 80);
 			return;
 		}
 

--- a/src/lib/components/PDFViewer.svelte
+++ b/src/lib/components/PDFViewer.svelte
@@ -1477,13 +1477,16 @@
 				// Commit pan first so the template re-render uses the correct position.
 				panOffset = { x: finalPanX, y: finalPanY };
 				await renderCurrentPage(finalScale);
+				// A newer gesture may have started while the render was in flight — bail
+				// out to avoid clobbering its accumulated state.
+				if (wheelZoomDebounceId !== myDebounceId) return;
 				wheelGestureBaseScale = finalScale;
 				// Reset to translate-only — canvas is now rendered at the correct scale.
 				if (contentWrapperDiv) {
 					contentWrapperDiv.style.transform = `translate(${finalPanX}px, ${finalPanY}px)`;
 				}
 				pdfState.update((s) => ({ ...s, scale: finalScale }));
-				if (wheelZoomDebounceId === myDebounceId) wheelZoomDebounceId = null;
+				wheelZoomDebounceId = null;
 			}, 80);
 			return;
 		}

--- a/src/lib/components/PDFViewer.svelte
+++ b/src/lib/components/PDFViewer.svelte
@@ -1409,6 +1409,33 @@
 		}
 	}
 
+	/**
+	 * Horizontal counterpart to scrollByDelta's pan: shifts panOffset.x when the
+	 * page is wider than the viewport (e.g. zoomed in or a landscape page).
+	 * Unlike the vertical axis there is no page navigation here.
+	 * Positive delta = swipe right, which moves the content left to reveal the
+	 * right side (matching scrollByDelta's vertical sign convention).
+	 */
+	function panHorizontalByDelta(delta: number) {
+		if (!pdfCanvas || !containerDiv || delta === 0) return;
+
+		const canvasWidth = parseFloat(pdfCanvas.style.width) || 0;
+		const viewportWidth = containerDiv.clientWidth;
+		const overflowX = canvasWidth - viewportWidth;
+
+		if (overflowX <= 0) return; // page fits horizontally — nothing to pan
+
+		const maxPanRight = overflowX / 2; // upper bound: reveals the left edge
+		const maxPanLeft = -(overflowX / 2); // lower bound: reveals the right edge
+		const scrollAmount = Math.min(Math.abs(delta), 100);
+
+		if (delta > 0) {
+			panOffset = { ...panOffset, x: Math.max(panOffset.x - scrollAmount, maxPanLeft) };
+		} else {
+			panOffset = { ...panOffset, x: Math.min(panOffset.x + scrollAmount, maxPanRight) };
+		}
+	}
+
 	// Fixed scroll amount for arrow key presses (in pixels)
 	const ARROW_KEY_SCROLL_PX = 60;
 
@@ -1496,13 +1523,21 @@
 
 		if (!pdfCanvas || !containerDiv) return;
 
-		// Normalize deltaY to pixels across browsers.
+		// Normalize deltaX/deltaY to pixels across browsers.
 		// Firefox reports deltaMode=1 (lines), most others report deltaMode=0 (pixels).
 		const LINE_HEIGHT = 16;
 		let pixelDelta = event.deltaY;
-		if (event.deltaMode === 1) pixelDelta *= LINE_HEIGHT;
-		else if (event.deltaMode === 2) pixelDelta *= containerDiv.clientHeight;
+		let pixelDeltaX = event.deltaX;
+		if (event.deltaMode === 1) {
+			pixelDelta *= LINE_HEIGHT;
+			pixelDeltaX *= LINE_HEIGHT;
+		} else if (event.deltaMode === 2) {
+			pixelDelta *= containerDiv.clientHeight;
+			pixelDeltaX *= containerDiv.clientWidth;
+		}
 
+		// Horizontal two-finger swipe pans a wide/zoomed page; no-op when it fits.
+		panHorizontalByDelta(pixelDeltaX);
 		scrollByDelta(pixelDelta);
 	}
 

--- a/src/lib/components/PDFViewer.svelte
+++ b/src/lib/components/PDFViewer.svelte
@@ -46,7 +46,7 @@
 	import TextSelectionOverlay from './TextSelectionOverlay.svelte';
 	import { TOOLBAR_HEIGHT } from '$lib/constants';
 	import { setWindowTitle } from '$lib/utils/tauriUtils';
-	import { GestureTracker, PanInertia } from '$lib/utils/gestureUtils';
+	import { GestureTracker, PanInertia, type Point2D } from '$lib/utils/gestureUtils';
 	import GestureHint from './GestureHint.svelte';
 
 	// Helper function to build window title with page info
@@ -121,8 +121,27 @@
 	let pinchStartDistance = 0;
 	let pinchStartScale = 0;
 	let lastPinchScale = 0; // updated every move; avoids regex-parsing CSS on pinch end
-	let pinchStartMidpoint = { x: 0, y: 0 }; // midpoint at gesture start for two-finger pan
+	let pinchStartMidpoint = { x: 0, y: 0 }; // midpoint at gesture start for two-finger pan (client coords)
 	let pinchStartPanOffset = { x: 0, y: 0 }; // panOffset snapshot at gesture start
+	// Container rect cached at gesture start. `cx`/`cy` are the half-extents, i.e.
+	// the wrapper's transform-origin (CSS default `center`) in container coords.
+	// Caching avoids a layout read on every pinch frame.
+	let pinchRect = { left: 0, top: 0, cx: 0, cy: 0 };
+	// The two pointer ids that started the pinch. The gesture is computed ONLY
+	// from these, so a stray third finger or a ghost pointer can't corrupt the
+	// distance/midpoint mid-gesture.
+	let pinchPointerA: number | null = null;
+	let pinchPointerB: number | null = null;
+	// Per-frame pinch state. We judge intent each frame (is the spread changing
+	// faster than the midpoint is moving?) so a two-finger drag scrolls without
+	// creeping into zoom, while spreading the fingers still zooms at any point in
+	// the gesture — the fluid pan-then-zoom feel of iPad Preview.
+	let pinchAccumScale = 1; // logical scale accumulated across zoom-dominant frames
+	let prevPinchDist = 0; // finger spread on the previous frame
+	let prevPinchMid = { x: 0, y: 0 }; // finger midpoint on the previous frame (client coords)
+	// A frame counts as zoom only if the spread changes more than the midpoint
+	// moves AND by more than this much — filters out sensor noise when near-still.
+	const ZOOM_FRAME_EPS_PX = 0.5;
 	let lastPinchPanX = 0; // visual-only pan X during pinch (committed on end)
 	let lastPinchPanY = 0; // visual-only pan Y during pinch (committed on end)
 	let pinchRafId: number | null = null; // rAF handle for batching two-finger updates
@@ -1143,25 +1162,44 @@
 	}
 
 	function handleContainerPointerDown(event: PointerEvent) {
-		// Stylus events that aren't captured by the freehand overlay should not
-		// feed the gesture tracker or trigger pan — let the overlay handle them.
-		if (event.pointerType === 'pen' && !hasActiveFreehandTool()) return;
+		// Pinch / two-finger pan are TOUCH-only gestures. A stylus is handled
+		// entirely by the drawing overlay and must never feed the gesture tracker:
+		// a single missed pen pointerup would leave a ghost "finger" that turns
+		// later one-finger pans into accidental zooms (and survives a zoom reset).
+		if (event.pointerType === 'pen') return;
 
-		if (gestureTracker) gestureTracker.track(event);
+		if (event.pointerType === 'touch' && gestureTracker) gestureTracker.track(event);
 		if (panInertia) panInertia.cancel();
 
 		// ── Two-finger gesture starts (pinch / two-finger pan) ──
-		if (gestureTracker && gestureTracker.count === 2) {
+		// Use >= 2 (not === 2) so a lingering ghost pointer can't block the start;
+		// we lock onto a definite pair below.
+		if (gestureTracker && !isPinching && gestureTracker.count >= 2) {
+			// Lock the gesture to this finger plus the most-recent other pointer.
+			const other = gestureTracker.otherMostRecentId(event.pointerId);
+			if (other === null) return; // shouldn't happen with count >= 2
+			pinchPointerA = other;
+			pinchPointerB = event.pointerId;
+
 			// Cancel any single-finger pan that was in progress
 			isPanning = false;
 			isPanConfirmed = false;
 			isPinching = true;
-			pinchStartDistance = gestureTracker.getPinchDistance();
+			pinchStartDistance = gestureTracker.distanceBetween(pinchPointerA, pinchPointerB) ?? 0;
 			pinchStartScale = $pdfState.scale;
-			pinchStartMidpoint = gestureTracker.getPinchMidpoint();
+			pinchStartMidpoint = gestureTracker.midpointBetween(pinchPointerA, pinchPointerB) ?? {
+				x: 0,
+				y: 0
+			};
 			pinchStartPanOffset = { ...panOffset };
+			const rect = containerDiv.getBoundingClientRect();
+			pinchRect = { left: rect.left, top: rect.top, cx: rect.width / 2, cy: rect.height / 2 };
 			lastPinchPanX = panOffset.x;
 			lastPinchPanY = panOffset.y;
+			lastPinchScale = pinchStartScale;
+			pinchAccumScale = pinchStartScale;
+			prevPinchDist = pinchStartDistance;
+			prevPinchMid = { ...pinchStartMidpoint };
 			event.preventDefault();
 
 			// Also cancel any drawing that may have started from the first finger
@@ -1170,6 +1208,13 @@
 				drawingEngine.endDrawing();
 				currentDrawingPath = [];
 			}
+			return;
+		}
+
+		// A pinch is already in progress (this is a 3rd+ finger): ignore it so it
+		// can't start a competing single-finger pan or capture the pointer.
+		if (isPinching) {
+			event.preventDefault();
 			return;
 		}
 
@@ -1190,40 +1235,91 @@
 	}
 
 	/**
+	 * Compute the translate component for a pinch gesture so that the document
+	 * point under the starting finger midpoint stays pinned under the current
+	 * midpoint, while scaled by `cssScale`.
+	 *
+	 * The wrapper scales around its center (CSS transform-origin default), so the
+	 * formula folds in that pivot `C`. With `translate(pan) scale(cssScale)` and
+	 * origin `C`, a point P maps to `C + pan + cssScale*(layout(P) - C)`. Pinning
+	 * the anchor (whose start screen pos is the start midpoint) to the current
+	 * midpoint and solving for `pan` gives the expression below. It is chosen so
+	 * the live CSS transform and the post-commit re-render (canvas grows from its
+	 * center) resolve to the same screen position — no jump on release.
+	 *
+	 * All inputs/outputs are in container-relative coordinates.
+	 */
+	function computePinchPan(currentMidpoint: Point2D, cssScale: number): Point2D {
+		const curMidX = currentMidpoint.x - pinchRect.left;
+		const curMidY = currentMidpoint.y - pinchRect.top;
+		const startMidX = pinchStartMidpoint.x - pinchRect.left;
+		const startMidY = pinchStartMidpoint.y - pinchRect.top;
+		return {
+			x: curMidX - pinchRect.cx - cssScale * (startMidX - pinchStartPanOffset.x - pinchRect.cx),
+			y: curMidY - pinchRect.cy - cssScale * (startMidY - pinchStartPanOffset.y - pinchRect.cy)
+		};
+	}
+
+	/**
 	 * rAF callback: compute pinch scale + two-finger pan in one batched frame.
 	 * By the time this fires, both fingers' pointermove events have been
 	 * processed by gestureTracker, so midpoint & distance are stable.
+	 *
+	 * Pan is always live (the midpoint is tracked 1:1, like two-finger scroll).
+	 * Zoom only accrues on frames where the finger spread changes faster than the
+	 * midpoint moves, so panning never creeps into zoom, yet spreading the fingers
+	 * zooms at any moment — including right after a pan.
 	 */
 	function applyPinchFrame() {
 		pinchRafId = null; // allow next frame to be scheduled
-		if (!gestureTracker || gestureTracker.count < 2 || pinchStartDistance <= 0) return;
+		if (!gestureTracker || pinchPointerA === null || pinchPointerB === null || pinchStartDistance <= 0)
+			return;
 
-		// Scale
-		const currentDist = gestureTracker.getPinchDistance();
-		const scaleRatio = currentDist / pinchStartDistance;
-		const newScale = Math.max(0.1, Math.min(10, pinchStartScale * scaleRatio));
+		// Distance/midpoint come ONLY from the two locked pointers.
+		const currentDist = gestureTracker.distanceBetween(pinchPointerA, pinchPointerB);
+		const currentMidpoint = gestureTracker.midpointBetween(pinchPointerA, pinchPointerB);
+		if (currentDist === null || currentMidpoint === null || currentDist <= 0) return;
 
-		// Pan: simple midpoint delta from gesture start
-		const currentMidpoint = gestureTracker.getPinchMidpoint();
-		lastPinchPanX = pinchStartPanOffset.x + (currentMidpoint.x - pinchStartMidpoint.x);
-		lastPinchPanY = pinchStartPanOffset.y + (currentMidpoint.y - pinchStartMidpoint.y);
+		// Per-frame intent: zoom only when the spread out-changes the midpoint move.
+		const dSpread = currentDist - prevPinchDist;
+		const dMid = Math.hypot(currentMidpoint.x - prevPinchMid.x, currentMidpoint.y - prevPinchMid.y);
+		if (Math.abs(dSpread) > dMid && Math.abs(dSpread) > ZOOM_FRAME_EPS_PX && prevPinchDist > 0) {
+			pinchAccumScale = Math.max(0.1, Math.min(10, pinchAccumScale * (currentDist / prevPinchDist)));
+		}
+		prevPinchDist = currentDist;
+		prevPinchMid = { x: currentMidpoint.x, y: currentMidpoint.y };
 
-		// Apply CSS transform for smooth visual feedback
-		const cssScale = newScale / $pdfState.scale;
-		lastPinchScale = newScale;
+		const cssScale = pinchAccumScale / pinchStartScale;
+
+		// Anchor the zoom around the finger midpoint AND track midpoint movement
+		// (two-finger pan) in one step. See computePinchPan() for the derivation.
+		const pan = computePinchPan(currentMidpoint, cssScale);
+		lastPinchPanX = pan.x;
+		lastPinchPanY = pan.y;
+
+		lastPinchScale = pinchAccumScale;
 		if (contentWrapperDiv) {
 			contentWrapperDiv.style.transform = `translate(${lastPinchPanX}px, ${lastPinchPanY}px) scale(${cssScale})`;
 		}
 	}
 
 	function handleContainerPointerMove(event: PointerEvent) {
-		if (gestureTracker) gestureTracker.track(event);
+		// Touch-only, mirroring handleContainerPointerDown — never track the pen.
+		if (event.pointerType === 'touch' && gestureTracker) gestureTracker.track(event);
 
 		// ── Pinch-to-zoom + two-finger pan ──
 		// We only mark the rAF as needed here; the actual computation is
 		// deferred to applyPinchFrame() so that BOTH fingers' pointermove
 		// events are processed before we compute midpoint & distance.
-		if (isPinching && gestureTracker && gestureTracker.count >= 2 && pinchStartDistance > 0) {
+		if (
+			isPinching &&
+			gestureTracker &&
+			pinchPointerA !== null &&
+			pinchPointerB !== null &&
+			gestureTracker.has(pinchPointerA) &&
+			gestureTracker.has(pinchPointerB) &&
+			pinchStartDistance > 0
+		) {
 			event.preventDefault();
 			if (pinchRafId === null) {
 				pinchRafId = requestAnimationFrame(applyPinchFrame);
@@ -1258,15 +1354,24 @@
 	}
 
 	async function handleContainerPointerUp(event: PointerEvent) {
-		// Snapshot midpoint BEFORE untracking so we can compute final pan position
+		// Is the lifted pointer one of the two driving the pinch?
+		const liftedPinchPointer =
+			isPinching && (event.pointerId === pinchPointerA || event.pointerId === pinchPointerB);
+
+		// Snapshot the pinch midpoint BEFORE untracking so we can compute the
+		// final pan position from the two locked pointers while both are present.
 		let freshMid: { x: number; y: number } | null = null;
-		if (gestureTracker && gestureTracker.count >= 2) {
-			freshMid = gestureTracker.getPinchMidpoint();
+		if (isPinching && pinchPointerA !== null && pinchPointerB !== null) {
+			freshMid = gestureTracker?.midpointBetween(pinchPointerA, pinchPointerB) ?? null;
 		}
 		if (gestureTracker) gestureTracker.untrack(event);
 
+		// A non-participating finger lifted (e.g. a palm/third touch): the pinch
+		// continues with its two locked pointers untouched.
+		if (isPinching && !liftedPinchPointer) return;
+
 		// ── Pinch ended: commit the final scale + pan ──
-		if (isPinching && gestureTracker && gestureTracker.count < 2) {
+		if (isPinching && liftedPinchPointer && gestureTracker) {
 			// Cancel any pending rAF so it doesn't fire after we commit
 			if (pinchRafId !== null) {
 				cancelAnimationFrame(pinchRafId);
@@ -1274,25 +1379,17 @@
 			}
 
 			if (pinchStartDistance > 0) {
-				// Compute final scale and render once
-				const currentDist =
-					gestureTracker.count === 1
-						? 0 // last finger lifted — use last known ratio
-						: gestureTracker.getPinchDistance();
-				let finalScale = $pdfState.scale;
-				if (currentDist > 0) {
-					const scaleRatio = currentDist / pinchStartDistance;
-					finalScale = Math.max(0.1, Math.min(10, pinchStartScale * scaleRatio));
-				} else if (lastPinchScale > 0) {
-					// Use last recorded scale value — no CSS parsing needed
-					finalScale = Math.max(0.1, Math.min(10, lastPinchScale));
-				}
+				// Compute final scale and render once. One of the locked pointers is
+				// now gone, so prefer the last value computed during the gesture.
+				const finalScale = lastPinchScale > 0 ? lastPinchScale : $pdfState.scale;
 
 				// Use the midpoint snapshot (captured before untrack) to recompute
-				// pan position if the rAF was cancelled and values are stale
+				// pan position if the rAF was cancelled and values are stale.
+				// Same anchored formula as the live frames so the commit doesn't jump.
 				if (freshMid) {
-					lastPinchPanX = pinchStartPanOffset.x + (freshMid.x - pinchStartMidpoint.x);
-					lastPinchPanY = pinchStartPanOffset.y + (freshMid.y - pinchStartMidpoint.y);
+					const pan = computePinchPan(freshMid, finalScale / pinchStartScale);
+					lastPinchPanX = pan.x;
+					lastPinchPanY = pan.y;
 				}
 
 				// Commit the visual pan position accumulated during the gesture
@@ -1317,6 +1414,11 @@
 			pinchStartPanOffset = { x: 0, y: 0 };
 			lastPinchPanX = 0;
 			lastPinchPanY = 0;
+			pinchPointerA = null;
+			pinchPointerB = null;
+			pinchAccumScale = 1;
+			prevPinchDist = 0;
+			prevPinchMid = { x: 0, y: 0 };
 
 			isPinching = false;
 			if (gestureTracker.count === 0) {
@@ -1578,8 +1680,34 @@
 		pdfState.update((state) => ({ ...state, scale: newScale }));
 	}
 
+	/**
+	 * Clear all in-flight touch gesture state. A failsafe so a stuck/ghost
+	 * pointer (e.g. from a missed pointerup) can never wedge pinch/pan: any
+	 * zoom-reset gives the user a clean slate.
+	 */
+	function resetGestureState() {
+		if (pinchRafId !== null) {
+			cancelAnimationFrame(pinchRafId);
+			pinchRafId = null;
+		}
+		if (panInertia) panInertia.cancel();
+		if (gestureTracker) gestureTracker.reset();
+		isPinching = false;
+		isPanning = false;
+		isPanConfirmed = false;
+		pinchStartDistance = 0;
+		pinchStartScale = 0;
+		lastPinchScale = 0;
+		pinchPointerA = null;
+		pinchPointerB = null;
+		pinchAccumScale = 1;
+		prevPinchDist = 0;
+		prevPinchMid = { x: 0, y: 0 };
+	}
+
 	export async function resetZoom() {
 		// Reset both zoom and pan position to center the PDF
+		resetGestureState();
 		panOffset = { x: 0, y: 0 };
 		const newScale = 1.0;
 		// CRITICAL: Render FIRST, update state AFTER
@@ -1596,6 +1724,7 @@
 			const containerWidth = containerDiv.clientWidth - (presentationMode ? 0 : 40); // Account for padding
 			const newScale = containerWidth / viewport.width;
 
+			resetGestureState();
 			panOffset = { x: 0, y: 0 };
 			// CRITICAL: Render FIRST, update state AFTER
 			await renderCurrentPage(newScale);
@@ -1614,6 +1743,7 @@
 			const containerHeight = containerDiv.clientHeight - (presentationMode ? 0 : TOOLBAR_HEIGHT); // Account for toolbar and page info
 			const newScale = containerHeight / viewport.height;
 
+			resetGestureState();
 			panOffset = { x: 0, y: 0 };
 			// CRITICAL: Render FIRST, update state AFTER
 			await renderCurrentPage(newScale);
@@ -1637,6 +1767,7 @@
 			const widthScale = containerWidth / viewport.width;
 			const newScale = Math.min(heightScale, widthScale);
 
+			resetGestureState();
 			panOffset = { x: 0, y: 0 };
 			// CRITICAL: Render FIRST, update state AFTER
 			await renderCurrentPage(newScale);

--- a/src/lib/components/PDFViewer.svelte
+++ b/src/lib/components/PDFViewer.svelte
@@ -1162,6 +1162,10 @@
 	}
 
 	function handleContainerPointerDown(event: PointerEvent) {
+		// Cancel any in-flight pan inertia on a fresh pointer-down — including a
+		// stylus, so the page can't keep gliding under the pen while drawing.
+		if (panInertia) panInertia.cancel();
+
 		// Pinch / two-finger pan are TOUCH-only gestures. A stylus is handled
 		// entirely by the drawing overlay and must never feed the gesture tracker:
 		// a single missed pen pointerup would leave a ghost "finger" that turns
@@ -1169,7 +1173,6 @@
 		if (event.pointerType === 'pen') return;
 
 		if (event.pointerType === 'touch' && gestureTracker) gestureTracker.track(event);
-		if (panInertia) panInertia.cancel();
 
 		// ── Two-finger gesture starts (pinch / two-finger pan) ──
 		// Use >= 2 (not === 2) so a lingering ghost pointer can't block the start;
@@ -1689,6 +1692,12 @@
 		if (pinchRafId !== null) {
 			cancelAnimationFrame(pinchRafId);
 			pinchRafId = null;
+		}
+		// Abort any pending Ctrl+wheel zoom commit so its (now stale) accumulated
+		// scale/pan can't fire after — and clobber — a zoom reset / fit done here.
+		if (wheelZoomDebounceId !== null) {
+			clearTimeout(wheelZoomDebounceId);
+			wheelZoomDebounceId = null;
 		}
 		if (panInertia) panInertia.cancel();
 		if (gestureTracker) gestureTracker.reset();

--- a/src/lib/components/PDFViewer.svelte
+++ b/src/lib/components/PDFViewer.svelte
@@ -1538,7 +1538,14 @@
 
 		// Horizontal two-finger swipe pans a wide/zoomed page; no-op when it fits.
 		panHorizontalByDelta(pixelDeltaX);
-		scrollByDelta(pixelDelta);
+
+		// Skip vertical handling when the gesture is clearly horizontal-dominant, so a
+		// sideways swipe can't scroll or (when zoomed out) flip pages via vertical noise.
+		// Require horizontal to dominate by 2x so genuine vertical scrolls — which carry
+		// minor per-event deltaX jitter on trackpads — aren't suppressed.
+		if (Math.abs(pixelDeltaX) <= Math.abs(pixelDelta) * 2) {
+			scrollByDelta(pixelDelta);
+		}
 	}
 
 	export async function goToPage(pageNumber: number) {

--- a/src/lib/components/PDFViewer.svelte
+++ b/src/lib/components/PDFViewer.svelte
@@ -1445,7 +1445,12 @@
 			}
 
 			const prevScale = wheelAccumulatedScale;
-			const factor = Math.pow(0.999, event.deltaY);
+			// Normalize deltaY to pixels (Firefox reports lines, some browsers report pages).
+			const LINE_HEIGHT = 16;
+			let zoomDelta = event.deltaY;
+			if (event.deltaMode === 1) zoomDelta *= LINE_HEIGHT;
+			else if (event.deltaMode === 2) zoomDelta *= containerDiv.clientHeight;
+			const factor = Math.pow(0.999, zoomDelta);
 			wheelAccumulatedScale = Math.max(0.1, Math.min(10, prevScale * factor));
 
 			// Cursor-anchored pan: keep the document point under the cursor fixed.

--- a/src/lib/components/PromoCard.svelte
+++ b/src/lib/components/PromoCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Video, Sun, Camera } from 'lucide-svelte';
+	import { Video, Sun, Camera, FileText } from 'lucide-svelte';
 
 	export let name: string;
 	export let tagline: string;
@@ -11,7 +11,8 @@
 	const iconMap: Record<string, typeof Video> = {
 		video: Video,
 		sun: Sun,
-		camera: Camera
+		camera: Camera,
+		'file-text': FileText
 	};
 
 	$: IconComponent = iconMap[icon] ?? Sun;

--- a/src/lib/components/StickyNote.svelte
+++ b/src/lib/components/StickyNote.svelte
@@ -144,8 +144,8 @@
 		}
 	};
 
-	// Handle mouse down for dragging
-	const handleMouseDown = (event: MouseEvent) => {
+	// Handle pointer down for dragging
+	const handlePointerDown = (event: PointerEvent) => {
 		if (isEditing || viewOnlyMode) return; // Disable dragging in view-only mode
 
 		event.preventDefault();
@@ -155,12 +155,15 @@
 		dragStartX = event.clientX - displayX;
 		dragStartY = event.clientY - displayY;
 
-		document.addEventListener('mousemove', handleMouseMove);
-		document.addEventListener('mouseup', handleMouseUp);
+		// Capture the pointer so move/up events are received even outside the element
+		(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+
+		document.addEventListener('pointermove', handlePointerMove);
+		document.addEventListener('pointerup', handlePointerUp);
 	};
 
-	// Handle mouse move for dragging
-	const handleMouseMove = (event: MouseEvent) => {
+	// Handle pointer move for dragging
+	const handlePointerMove = (event: PointerEvent) => {
 		if (isDragging) {
 			// Calculate new display position
 			const newDisplayX = event.clientX - dragStartX;
@@ -228,16 +231,16 @@
 		}
 	};
 
-	// Handle mouse up
-	const handleMouseUp = () => {
+	// Handle pointer up
+	const handlePointerUp = () => {
 		isDragging = false;
 		isResizing = false;
-		document.removeEventListener('mousemove', handleMouseMove);
-		document.removeEventListener('mouseup', handleMouseUp);
+		document.removeEventListener('pointermove', handlePointerMove);
+		document.removeEventListener('pointerup', handlePointerUp);
 	};
 
-	// Handle resize handle mouse down
-	const handleResizeMouseDown = (event: MouseEvent) => {
+	// Handle resize handle pointer down
+	const handleResizePointerDown = (event: PointerEvent) => {
 		if (viewOnlyMode) return; // Disable resizing in view-only mode
 		event.preventDefault();
 		event.stopPropagation();
@@ -248,8 +251,11 @@
 		resizeStartWidth = displayWidth;
 		resizeStartHeight = displayHeight;
 
-		document.addEventListener('mousemove', handleMouseMove);
-		document.addEventListener('mouseup', handleMouseUp);
+		// Capture pointer on the resize handle
+		(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+
+		document.addEventListener('pointermove', handlePointerMove);
+		document.addEventListener('pointerup', handlePointerUp);
 	};
 
 	// Handle delete
@@ -296,7 +302,7 @@
 	class:editing={isEditing}
 	class:dragging={isDragging}
 	class:resizing={isResizing}
-	on:mousedown={handleMouseDown}
+	on:pointerdown={handlePointerDown}
 	on:dblclick={handleDoubleClick}
 	on:contextmenu={handleContextMenu}
 	on:keydown={(e) => {
@@ -353,7 +359,7 @@
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
 			class="resize-handle"
-			on:mousedown|stopPropagation={handleResizeMouseDown}
+			on:pointerdown|stopPropagation={handleResizePointerDown}
 			title="Drag to resize"
 		></div>
 	{/if}

--- a/src/lib/components/StickyNote.svelte
+++ b/src/lib/components/StickyNote.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher, onMount } from 'svelte';
+	import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 	import type { StickyNoteAnnotation } from '$lib/stores/drawingStore';
 	import {
 		transformPoint,
@@ -160,6 +160,7 @@
 
 		document.addEventListener('pointermove', handlePointerMove);
 		document.addEventListener('pointerup', handlePointerUp);
+		document.addEventListener('pointercancel', handlePointerCancel);
 	};
 
 	// Handle pointer move for dragging
@@ -231,13 +232,26 @@
 		}
 	};
 
+	const removePointerListeners = () => {
+		document.removeEventListener('pointermove', handlePointerMove);
+		document.removeEventListener('pointerup', handlePointerUp);
+		document.removeEventListener('pointercancel', handlePointerCancel);
+	};
+
 	// Handle pointer up
 	const handlePointerUp = () => {
 		isDragging = false;
 		isResizing = false;
-		document.removeEventListener('pointermove', handlePointerMove);
-		document.removeEventListener('pointerup', handlePointerUp);
+		removePointerListeners();
 	};
+
+	const handlePointerCancel = () => {
+		isDragging = false;
+		isResizing = false;
+		removePointerListeners();
+	};
+
+	onDestroy(removePointerListeners);
 
 	// Handle resize handle pointer down
 	const handleResizePointerDown = (event: PointerEvent) => {
@@ -256,6 +270,7 @@
 
 		document.addEventListener('pointermove', handlePointerMove);
 		document.addEventListener('pointerup', handlePointerUp);
+		document.addEventListener('pointercancel', handlePointerCancel);
 	};
 
 	// Handle delete

--- a/src/lib/components/StickyNote.svelte
+++ b/src/lib/components/StickyNote.svelte
@@ -339,6 +339,7 @@
 	{#if !viewOnlyMode}
 		<button
 			class="delete-btn"
+			on:pointerdown|stopPropagation
 			on:click|stopPropagation={handleDelete}
 			title="Delete sticky note"
 			aria-label="Delete sticky note"

--- a/src/lib/components/StickyNote.svelte
+++ b/src/lib/components/StickyNote.svelte
@@ -25,6 +25,7 @@
 	let isEditing = false;
 	let isDragging = false;
 	let isResizing = false;
+	let activePointerId: number | null = null;
 	let dragStartX = 0;
 	let dragStartY = 0;
 	let resizeStartX = 0;
@@ -147,6 +148,7 @@
 	// Handle pointer down for dragging
 	const handlePointerDown = (event: PointerEvent) => {
 		if (isEditing || viewOnlyMode) return; // Disable dragging in view-only mode
+		if (!event.isPrimary || event.button !== 0) return;
 
 		event.preventDefault();
 		event.stopPropagation();
@@ -154,6 +156,7 @@
 		isDragging = true;
 		dragStartX = event.clientX - displayX;
 		dragStartY = event.clientY - displayY;
+		activePointerId = event.pointerId;
 
 		// Capture the pointer so move/up events are received even outside the element
 		(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
@@ -165,6 +168,7 @@
 
 	// Handle pointer move for dragging
 	const handlePointerMove = (event: PointerEvent) => {
+		if (event.pointerId !== activePointerId) return;
 		if (isDragging) {
 			// Calculate new display position
 			const newDisplayX = event.clientX - dragStartX;
@@ -239,15 +243,19 @@
 	};
 
 	// Handle pointer up
-	const handlePointerUp = () => {
+	const handlePointerUp = (event: PointerEvent) => {
+		if (event.pointerId !== activePointerId) return;
 		isDragging = false;
 		isResizing = false;
+		activePointerId = null;
 		removePointerListeners();
 	};
 
-	const handlePointerCancel = () => {
+	const handlePointerCancel = (event: PointerEvent) => {
+		if (event.pointerId !== activePointerId) return;
 		isDragging = false;
 		isResizing = false;
+		activePointerId = null;
 		removePointerListeners();
 	};
 
@@ -256,6 +264,7 @@
 	// Handle resize handle pointer down
 	const handleResizePointerDown = (event: PointerEvent) => {
 		if (viewOnlyMode) return; // Disable resizing in view-only mode
+		if (!event.isPrimary || event.button !== 0) return;
 		event.preventDefault();
 		event.stopPropagation();
 
@@ -264,6 +273,7 @@
 		resizeStartY = event.clientY;
 		resizeStartWidth = displayWidth;
 		resizeStartHeight = displayHeight;
+		activePointerId = event.pointerId;
 
 		// Capture pointer on the resize handle
 		(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);

--- a/src/lib/components/StickyNoteOverlay.svelte
+++ b/src/lib/components/StickyNoteOverlay.svelte
@@ -24,14 +24,32 @@
 	let overlayElement: HTMLDivElement;
 	let isCreatingNote = false;
 
+	// Tap detection state for pointer events
+	let pointerDownX = 0;
+	let pointerDownY = 0;
+
 	// Listen for note tool activation and click events
 	$: isNoteTool = $drawingState.tool === 'note';
 
-	// Handle click to create new sticky note
-	const handleContainerClick = (event: MouseEvent) => {
+	// Record pointer-down position for tap detection
+	const handleContainerPointerDown = (event: PointerEvent) => {
+		pointerDownX = event.clientX;
+		pointerDownY = event.clientY;
+	};
+
+	// Handle pointer-up to create new sticky note (tap detection)
+	const handleContainerPointerUp = (event: PointerEvent) => {
 		if (!isNoteTool || isCreatingNote || viewOnlyMode) return;
 
-		// Don't create note if clicking on an existing note
+		// Only handle primary button / stylus / touch (not right-click)
+		if (event.button !== 0 && event.button !== -1) return;
+
+		// Tap detection: ignore if the pointer moved more than 10px (scroll/drag)
+		const dx = event.clientX - pointerDownX;
+		const dy = event.clientY - pointerDownY;
+		if (Math.sqrt(dx * dx + dy * dy) >= 10) return;
+
+		// Don't create note if tapping on an existing note
 		const target = event.target as HTMLElement;
 		if (target.closest('.sticky-note')) return;
 
@@ -149,7 +167,6 @@
 	});
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <div
 	bind:this={overlayElement}
@@ -157,9 +174,11 @@
 	class:note-tool-active={isNoteTool}
 	style:width="{containerWidth}px"
 	style:height="{containerHeight}px"
-	on:click={handleContainerClick}
+	style:touch-action={isNoteTool ? 'none' : 'auto'}
+	on:pointerdown={handleContainerPointerDown}
+	on:pointerup={handleContainerPointerUp}
 	role="application"
-	aria-label="Sticky notes area - click to create new note when note tool is active"
+	aria-label="Sticky notes area - tap to create new note when note tool is active"
 >
 	{#each $currentPageStickyNotes as note (note.id)}
 		<StickyNote
@@ -181,7 +200,7 @@
 		<div class="note-tool-hint">
 			<div class="hint-content">
 				<div class="hint-icon">📝</div>
-				<div class="hint-text">Click anywhere to create a sticky note</div>
+				<div class="hint-text">Tap anywhere to create a sticky note</div>
 			</div>
 		</div>
 	{/if}

--- a/src/lib/components/StickyNoteOverlay.svelte
+++ b/src/lib/components/StickyNoteOverlay.svelte
@@ -27,6 +27,7 @@
 	// Tap detection state for pointer events
 	let pointerDownX = 0;
 	let pointerDownY = 0;
+	let activePointerId: number | null = null;
 
 	// Listen for note tool activation and click events
 	$: isNoteTool = $drawingState.tool === 'note';
@@ -35,14 +36,21 @@
 	const handleContainerPointerDown = (event: PointerEvent) => {
 		pointerDownX = event.clientX;
 		pointerDownY = event.clientY;
+		activePointerId = event.pointerId;
 		// Prevent PDFViewer's container from capturing the pointer for panning,
 		// which would redirect the matching pointerup away from this overlay.
 		if (isNoteTool) event.stopPropagation();
 	};
 
+	const handleContainerPointerCancel = (event: PointerEvent) => {
+		if (event.pointerId === activePointerId) activePointerId = null;
+	};
+
 	// Handle pointer-up to create new sticky note (tap detection)
 	const handleContainerPointerUp = (event: PointerEvent) => {
 		if (!isNoteTool || isCreatingNote || viewOnlyMode) return;
+		if (event.pointerId !== activePointerId) return;
+		activePointerId = null;
 
 		// Only handle primary button / stylus / touch (not right-click)
 		if (event.button !== 0 && event.button !== -1) return;
@@ -179,6 +187,7 @@
 	style:height="{containerHeight}px"
 	style:touch-action={isNoteTool ? 'none' : 'auto'}
 	on:pointerdown={handleContainerPointerDown}
+	on:pointercancel={handleContainerPointerCancel}
 	on:pointerup={handleContainerPointerUp}
 	role="application"
 	aria-label="Sticky notes area - tap to create new note when note tool is active"

--- a/src/lib/components/StickyNoteOverlay.svelte
+++ b/src/lib/components/StickyNoteOverlay.svelte
@@ -35,6 +35,9 @@
 	const handleContainerPointerDown = (event: PointerEvent) => {
 		pointerDownX = event.clientX;
 		pointerDownY = event.clientY;
+		// Prevent PDFViewer's container from capturing the pointer for panning,
+		// which would redirect the matching pointerup away from this overlay.
+		if (isNoteTool) event.stopPropagation();
 	};
 
 	// Handle pointer-up to create new sticky note (tap detection)

--- a/src/lib/components/StickyNoteOverlay.svelte
+++ b/src/lib/components/StickyNoteOverlay.svelte
@@ -34,6 +34,8 @@
 
 	// Record pointer-down position for tap detection
 	const handleContainerPointerDown = (event: PointerEvent) => {
+		// Ignore secondary touches so they can't overwrite the tracked pointer.
+		if (!event.isPrimary) return;
 		pointerDownX = event.clientX;
 		pointerDownY = event.clientY;
 		activePointerId = event.pointerId;

--- a/src/lib/components/TextOverlay.svelte
+++ b/src/lib/components/TextOverlay.svelte
@@ -509,6 +509,7 @@
 				{#if !viewOnlyMode}
 					<button
 						class="text-box-delete-btn"
+						on:pointerdown|stopPropagation
 						on:click|stopPropagation={() => handleDelete(annotation)}
 						title="Delete text annotation"
 						aria-label="Delete text annotation"
@@ -537,6 +538,7 @@
 				{#if !viewOnlyMode}
 					<button
 						class="text-box-delete-btn"
+						on:pointerdown|stopPropagation
 						on:click|stopPropagation={() => handleDelete(annotation)}
 						title="Delete text annotation"
 						aria-label="Delete text annotation"

--- a/src/lib/components/TextOverlay.svelte
+++ b/src/lib/components/TextOverlay.svelte
@@ -69,6 +69,9 @@
 
 	// Handle pointerup on overlay to create new text annotation (supports mouse, pen, and touch)
 	function handleOverlayPointerUp(event: PointerEvent) {
+		// Ignore non-primary button presses (e.g. right-click)
+		if (!event.isPrimary || event.button !== 0) return;
+
 		// Only handle clicks when text tool is active and not in view-only mode
 		if ($drawingState.tool !== 'text' || viewOnlyMode) return;
 
@@ -413,6 +416,13 @@
 		resizeDirection = null;
 	}
 
+	function handlePointerCancel() {
+		draggedAnnotation = null;
+		isResizing = false;
+		resizingAnnotation = null;
+		resizeDirection = null;
+	}
+
 	// Handle resize handle pointer down (supports mouse, pen, and touch)
 	function handleResizePointerDown(
 		event: PointerEvent,
@@ -443,10 +453,12 @@
 	onMount(() => {
 		document.addEventListener('pointermove', handlePointerMove);
 		document.addEventListener('pointerup', handlePointerUp);
+		document.addEventListener('pointercancel', handlePointerCancel);
 
 		return () => {
 			document.removeEventListener('pointermove', handlePointerMove);
 			document.removeEventListener('pointerup', handlePointerUp);
+			document.removeEventListener('pointercancel', handlePointerCancel);
 		};
 	});
 

--- a/src/lib/components/TextOverlay.svelte
+++ b/src/lib/components/TextOverlay.svelte
@@ -67,10 +67,14 @@
 		return `text_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 	}
 
-	// Handle click on overlay to create new text annotation
-	function handleOverlayClick(event: MouseEvent) {
+	// Handle pointerup on overlay to create new text annotation (supports mouse, pen, and touch)
+	function handleOverlayPointerUp(event: PointerEvent) {
 		// Only handle clicks when text tool is active and not in view-only mode
 		if ($drawingState.tool !== 'text' || viewOnlyMode) return;
+
+		// Guard: pointerup fires after drags too (unlike click). Don't create an annotation
+		// when the user is just releasing from a drag or resize gesture.
+		if (draggedAnnotation || isResizing) return;
 
 		// Don't create new annotation if clicking on existing text
 		if (event.target !== overlayContainer) return;
@@ -294,7 +298,7 @@
 	let dragStart = { x: 0, y: 0 };
 	let annotationStart = { x: 0, y: 0 };
 
-	function handleMouseDown(event: MouseEvent, annotation: TextAnnotation) {
+	function handlePointerDown(event: PointerEvent, annotation: TextAnnotation) {
 		// Don't start drag if we're editing, resizing, or in view-only mode
 		if (editingAnnotation || isResizing || viewOnlyMode) return;
 
@@ -309,7 +313,7 @@
 		event.preventDefault();
 	}
 
-	function handleMouseMove(event: MouseEvent) {
+	function handlePointerMove(event: PointerEvent) {
 		if (draggedAnnotation) {
 			const deltaX = event.clientX - dragStart.x;
 			const deltaY = event.clientY - dragStart.y;
@@ -402,16 +406,16 @@
 		}
 	}
 
-	function handleMouseUp() {
+	function handlePointerUp() {
 		draggedAnnotation = null;
 		isResizing = false;
 		resizingAnnotation = null;
 		resizeDirection = null;
 	}
 
-	// Handle resize handle mouse down
-	function handleResizeMouseDown(
-		event: MouseEvent,
+	// Handle resize handle pointer down (supports mouse, pen, and touch)
+	function handleResizePointerDown(
+		event: PointerEvent,
 		annotation: TextAnnotation,
 		direction: 'se' | 'e' | 's' | 'w' | 'n'
 	) {
@@ -437,12 +441,12 @@
 	}
 
 	onMount(() => {
-		document.addEventListener('mousemove', handleMouseMove);
-		document.addEventListener('mouseup', handleMouseUp);
+		document.addEventListener('pointermove', handlePointerMove);
+		document.addEventListener('pointerup', handlePointerUp);
 
 		return () => {
-			document.removeEventListener('mousemove', handleMouseMove);
-			document.removeEventListener('mouseup', handleMouseUp);
+			document.removeEventListener('pointermove', handlePointerMove);
+			document.removeEventListener('pointerup', handlePointerUp);
 		};
 	});
 
@@ -459,8 +463,8 @@
 	class:cursor-crosshair={$drawingState.tool === 'text' && !editingAnnotation}
 	class:pointer-events-auto={$drawingState.tool === 'text'}
 	class:pointer-events-none={$drawingState.tool !== 'text'}
-	style="width: {canvasWidth}px; height: {canvasHeight}px; z-index: 4;"
-	on:click={handleOverlayClick}
+	style="width: {canvasWidth}px; height: {canvasHeight}px; z-index: 4; touch-action: none;"
+	on:pointerup={handleOverlayPointerUp}
 	role="application"
 	aria-label="Text annotation overlay"
 	tabindex="-1"
@@ -510,7 +514,7 @@
 				class:text-box-selected={$selectedTextAnnotationId === annotation.id}
 				style="left: {pos.x}px; top: {pos.y}px; width: {displayWidth}px; height: {displayHeight}px; transform: rotate({rotation + (annotation.rotation || 0)}deg); transform-origin: top left;"
 				on:dblclick={() => handleAnnotationDoubleClick(annotation)}
-				on:mousedown={(e) => handleMouseDown(e, annotation)}
+				on:pointerdown={(e) => handlePointerDown(e, annotation)}
 				on:keydown={(e) => handleAnnotationKeyDown(e, annotation)}
 				role="button"
 				tabindex="0"
@@ -544,7 +548,7 @@
 					<!-- svelte-ignore a11y-no-static-element-interactions -->
 					<div
 						class="text-box-resize-handle resize-se"
-						on:mousedown|stopPropagation={(e) => handleResizeMouseDown(e, annotation, 'se')}
+						on:pointerdown|stopPropagation={(e) => handleResizePointerDown(e, annotation, 'se')}
 						title="Drag to resize"
 						role="button"
 						tabindex="0"
@@ -555,25 +559,25 @@
 					<!-- svelte-ignore a11y-no-static-element-interactions -->
 					<div
 						class="text-box-resize-handle resize-e"
-						on:mousedown|stopPropagation={(e) => handleResizeMouseDown(e, annotation, 'e')}
+						on:pointerdown|stopPropagation={(e) => handleResizePointerDown(e, annotation, 'e')}
 						title="Drag to resize width"
 					></div>
 					<!-- svelte-ignore a11y-no-static-element-interactions -->
 					<div
 						class="text-box-resize-handle resize-s"
-						on:mousedown|stopPropagation={(e) => handleResizeMouseDown(e, annotation, 's')}
+						on:pointerdown|stopPropagation={(e) => handleResizePointerDown(e, annotation, 's')}
 						title="Drag to resize height"
 					></div>
 					<!-- svelte-ignore a11y-no-static-element-interactions -->
 					<div
 						class="text-box-resize-handle resize-w"
-						on:mousedown|stopPropagation={(e) => handleResizeMouseDown(e, annotation, 'w')}
+						on:pointerdown|stopPropagation={(e) => handleResizePointerDown(e, annotation, 'w')}
 						title="Drag to resize width"
 					></div>
 					<!-- svelte-ignore a11y-no-static-element-interactions -->
 					<div
 						class="text-box-resize-handle resize-n"
-						on:mousedown|stopPropagation={(e) => handleResizeMouseDown(e, annotation, 'n')}
+						on:pointerdown|stopPropagation={(e) => handleResizePointerDown(e, annotation, 'n')}
 						title="Drag to resize height"
 					></div>
 				{/if}

--- a/src/lib/components/TextOverlay.svelte
+++ b/src/lib/components/TextOverlay.svelte
@@ -476,6 +476,7 @@
 	class:pointer-events-auto={$drawingState.tool === 'text'}
 	class:pointer-events-none={$drawingState.tool !== 'text'}
 	style="width: {canvasWidth}px; height: {canvasHeight}px; z-index: 4; touch-action: none;"
+	on:pointerdown|stopPropagation
 	on:pointerup={handleOverlayPointerUp}
 	role="application"
 	aria-label="Text annotation overlay"

--- a/src/lib/components/TextOverlay.svelte
+++ b/src/lib/components/TextOverlay.svelte
@@ -300,10 +300,12 @@
 	let draggedAnnotation: TextAnnotation | null = null;
 	let dragStart = { x: 0, y: 0 };
 	let annotationStart = { x: 0, y: 0 };
+	let activePointerId: number | null = null;
 
 	function handlePointerDown(event: PointerEvent, annotation: TextAnnotation) {
 		// Don't start drag if we're editing, resizing, or in view-only mode
 		if (editingAnnotation || isResizing || viewOnlyMode) return;
+		if (!event.isPrimary || event.button !== 0) return;
 
 		// Select this annotation when clicked
 		selectTextAnnotation(annotation.id);
@@ -312,11 +314,13 @@
 		dragStart = { x: event.clientX, y: event.clientY };
 		const pos = getDisplayPosition(annotation);
 		annotationStart = { x: pos.x, y: pos.y };
+		activePointerId = event.pointerId;
 
 		event.preventDefault();
 	}
 
 	function handlePointerMove(event: PointerEvent) {
+		if (activePointerId !== null && event.pointerId !== activePointerId) return;
 		if (draggedAnnotation) {
 			const deltaX = event.clientX - dragStart.x;
 			const deltaY = event.clientY - dragStart.y;
@@ -409,14 +413,18 @@
 		}
 	}
 
-	function handlePointerUp() {
+	function handlePointerUp(event: PointerEvent) {
+		if (event.pointerId !== activePointerId) return;
+		activePointerId = null;
 		draggedAnnotation = null;
 		isResizing = false;
 		resizingAnnotation = null;
 		resizeDirection = null;
 	}
 
-	function handlePointerCancel() {
+	function handlePointerCancel(event: PointerEvent) {
+		if (event.pointerId !== activePointerId) return;
+		activePointerId = null;
 		draggedAnnotation = null;
 		isResizing = false;
 		resizingAnnotation = null;
@@ -430,6 +438,7 @@
 		direction: 'se' | 'e' | 's' | 'w' | 'n'
 	) {
 		if (viewOnlyMode || editingAnnotation) return;
+		if (!event.isPrimary || event.button !== 0) return;
 
 		event.preventDefault();
 		event.stopPropagation();
@@ -439,6 +448,7 @@
 		resizeDirection = direction;
 		resizeStartX = event.clientX;
 		resizeStartY = event.clientY;
+		activePointerId = event.pointerId;
 
 		// Get current display dimensions and position
 		const safeScale = getSafeScale();

--- a/src/lib/components/TextOverlay.svelte
+++ b/src/lib/components/TextOverlay.svelte
@@ -413,8 +413,7 @@
 		}
 	}
 
-	function handlePointerUp(event: PointerEvent) {
-		if (event.pointerId !== activePointerId) return;
+	function resetPointerState() {
 		activePointerId = null;
 		draggedAnnotation = null;
 		isResizing = false;
@@ -422,13 +421,14 @@
 		resizeDirection = null;
 	}
 
+	function handlePointerUp(event: PointerEvent) {
+		if (event.pointerId !== activePointerId) return;
+		resetPointerState();
+	}
+
 	function handlePointerCancel(event: PointerEvent) {
 		if (event.pointerId !== activePointerId) return;
-		activePointerId = null;
-		draggedAnnotation = null;
-		isResizing = false;
-		resizingAnnotation = null;
-		resizeDirection = null;
+		resetPointerState();
 	}
 
 	// Handle resize handle pointer down (supports mouse, pen, and touch)

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -246,6 +246,9 @@
 		if (!target.closest('.export-menu-container')) {
 			showExportMenu = false;
 		}
+		if (!target.closest('.view-menu-container')) {
+			showViewMenu = false;
+		}
 	}
 </script>
 
@@ -358,9 +361,12 @@
 							<ZoomOut size={18} />
 						</button>
 					</Tooltip>
+				</div>
 
+				<!-- Tablet + Desktop: View options (Reset / Fit) dropdown -->
+				<div class="hidden md:flex items-center space-x-2">
 					<!-- View dropdown menu -->
-					<div class="relative">
+					<div class="relative view-menu-container">
 						<Tooltip content="View options (Reset, Fit)">
 							<button
 								class="tool-button h-8 w-8 flex items-center justify-center"
@@ -1239,8 +1245,8 @@
 									{/if}
 								</div>
 
-								<!-- Zoom controls -->
-								<div class="space-y-1 mb-3">
+								<!-- Zoom controls (phones only — tablet+ show them in the toolbar) -->
+								<div class="space-y-1 mb-3 md:hidden">
 									<button
 										class="w-full text-left p-2 rounded-lg hover:bg-sage/10 transition-colors text-sm flex items-center gap-2"
 										on:click={() => {
@@ -1372,7 +1378,7 @@
 
 <!-- Bottom Toolbar - Drawing tools for small screens -->
 <div class="toolbar-bottom fixed bottom-4 left-4 right-4 z-50 lg:hidden">
-	<div class="floating-panel !py-2 !px-3 overflow-x-auto relative">
+	<div class="floating-panel !py-2 !px-3 overflow-x-auto relative flex justify-center">
 		<!-- Left fade indicator -->
 		<div
 			class="absolute left-0 top-0 bottom-0 w-4 bg-gradient-to-r from-white/80 dark:from-gray-800/80 to-transparent pointer-events-none z-[5]"

--- a/src/lib/data/promoCards.json
+++ b/src/lib/data/promoCards.json
@@ -23,5 +23,13 @@
     "description": "Auto-beautify screenshots with padding, shadows, and gradients",
     "href": "https://doublshot.com",
     "icon": "camera"
+  },
+  {
+    "id": "paperman",
+    "name": "Paperman",
+    "tagline": "Make Your Screen Feel Like Paper",
+    "description": "Applies a subtle matte texture to your display to reduce eye strain — no color shifting, zero CPU impact",
+    "href": "https://paperman.cc",
+    "icon": "file-text"
   }
 ]

--- a/src/lib/data/promoCards.json
+++ b/src/lib/data/promoCards.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": "paperman",
+    "name": "Paperman",
+    "tagline": "Make Your Screen Feel Like Paper",
+    "description": "Applies a subtle matte texture to your display to reduce eye strain — no color shifting, zero CPU impact",
+    "href": "https://paperman.cc",
+    "icon": "file-text"
+  },
+  {
     "id": "glucose-player",
     "name": "Glucose",
     "tagline": "The No-UI Video Player",
@@ -23,13 +31,5 @@
     "description": "Auto-beautify screenshots with padding, shadows, and gradients",
     "href": "https://doublshot.com",
     "icon": "camera"
-  },
-  {
-    "id": "paperman",
-    "name": "Paperman",
-    "tagline": "Make Your Screen Feel Like Paper",
-    "description": "Applies a subtle matte texture to your display to reduce eye strain — no color shifting, zero CPU impact",
-    "href": "https://paperman.cc",
-    "icon": "file-text"
   }
 ]

--- a/src/lib/utils/gestureUtils.ts
+++ b/src/lib/utils/gestureUtils.ts
@@ -63,6 +63,44 @@ export class GestureTracker {
         return null;
     }
 
+    /** Whether a specific pointer id is currently tracked. */
+    has(id: number): boolean {
+        return this.activePointers.has(id);
+    }
+
+    /**
+     * The most recently added pointer whose id is not `exclude`, or null.
+     * Used to pick a pinch's second pointer at gesture start without being
+     * fooled by stale/ghost pointers that lingered from earlier touches.
+     */
+    otherMostRecentId(exclude: number): number | null {
+        let result: number | null = null;
+        for (const id of this.activePointers.keys()) {
+            if (id !== exclude) result = id; // later entries are more recent
+        }
+        return result;
+    }
+
+    /**
+     * Distance between two SPECIFIC pointers, or null if either is missing.
+     * Scoping to fixed ids keeps a pinch immune to a third finger or a ghost
+     * pointer changing which pair `getPinchDistance()` would otherwise pick.
+     */
+    distanceBetween(id1: number, id2: number): number | null {
+        const a = this.activePointers.get(id1);
+        const b = this.activePointers.get(id2);
+        if (!a || !b) return null;
+        return Math.sqrt((a.clientX - b.clientX) ** 2 + (a.clientY - b.clientY) ** 2);
+    }
+
+    /** Midpoint between two SPECIFIC pointers, or null if either is missing. */
+    midpointBetween(id1: number, id2: number): Point2D | null {
+        const a = this.activePointers.get(id1);
+        const b = this.activePointers.get(id2);
+        if (!a || !b) return null;
+        return { x: (a.clientX + b.clientX) / 2, y: (a.clientY + b.clientY) / 2 };
+    }
+
     /** Clear all tracked pointers. */
     reset(): void {
         this.activePointers.clear();


### PR DESCRIPTION
Stylus (pen) input on tablets was getting stuck in zoom mode instead of drawing because Arrow, Text, and StickyNote overlays only listened to mouse events. Pointer events (pointerType='pen') bubbled up to the container's gesture tracker and triggered zoom.

- ArrowOverlay: mouse → pointer events; use setPointerCapture instead of document-level listeners to avoid double-firing; add pointercancel handler
- TextOverlay: mouse/click → pointer events; add drag-release guard in handleOverlayPointerUp to prevent phantom annotation creation on drag end
- StickyNoteOverlay: click → pointerdown/pointerup with 10px tap detection
- StickyNote: mouse → pointer events with setPointerCapture on drag/resize
- PDFViewer: early-return pen guard in handleContainerPointerDown so uncaptured stylus events never feed the gesture tracker

Trackpad pinch-to-zoom (Ctrl+wheel) was non-functional because reactive writes to panOffset and pdfState during the gesture triggered Svelte re-renders that immediately reset contentWrapperDiv.style.transform back to translate-only, destroying the CSS scale. Fix mirrors the touch-pinch pattern: accumulate in local variables (wheelAccumulatedScale, wheelCurrentPanX/Y) with no reactive writes during the gesture, apply CSS translate+scale imperatively, and commit to reactive state only in the debounced re-render callback.

Also adds Paperman (paperman.cc) to the promo card rotation.